### PR TITLE
Tweak `maxfps` to be friendly to 144 Hz displays

### DIFF
--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -645,7 +645,7 @@ void swapbuffers(bool overlay)
 }
 
 VAR(IDF_PERSIST, menufps, 0, 60, 1000);
-VAR(IDF_PERSIST, maxfps, 0, 125, 1000);
+VAR(IDF_PERSIST, maxfps, 0, 144, 1000);
 
 
 void limitfps(int &millis, int curmillis)


### PR DESCRIPTION
These new default values result in a smoother user experience for owners of 144 Hz displays, as they won't have to anything specific to use their display to its full extent.