### PR TITLE
Adjust the `maxfps` menu slider

### DIFF
--- a/config/ui/settings.cfg
+++ b/config/ui/settings.cfg
@@ -339,7 +339,7 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                         uialign -1 0
                                     ]
                                     uihlist $ui_padbutton [
-                                        uihorzslider "maxfps" 5 200 1 0.2 0.025 [
+                                        uihorzslider "maxfps" 30 240 1 0.2 0.025 [
                                             uivlist 0 [
                                                 uifill 0.050 0
                                                 uitext $maxfps


### PR DESCRIPTION
The minimum value has been raised, as very low `maxfps` values make menus difficult to control.

The maximum value has been raised to account for 240 Hz displays, which have the highest frequency available on the market as of this commit.