### PR TITLE
Particle wind optimizations

### DIFF
--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -122,7 +122,6 @@ enum { CON_DEBUG = 0, CON_EVENT, CON_GAME, CON_MESG, CON_MAX };
 #include "texture.h"
 #include "bih.h"
 #include "model.h"
-#include "wind.h"
 
 extern physent *camera1, camera;
 extern mapz hdr;

--- a/src/engine/wind.cpp
+++ b/src/engine/wind.cpp
@@ -76,6 +76,8 @@ static windemitter *getemitter(extentity *e = NULL)
 
 static void putemitter(windemitter *we)
 {
+    if(we->unused) return;
+
     // invalidate the external handle
     if(we->hook) *we->hook = NULL;
 

--- a/src/engine/wind.cpp
+++ b/src/engine/wind.cpp
@@ -190,13 +190,14 @@ vec getwind(const vec &o, const dynent *d)
         if(we->unused) continue;
 
         const vec &eo = we->attrs.o;
+        float dist = o.dist(eo);
 
         // outside the radius
-        if(we->attrs.radius > 0 && o.dist(eo) > we->attrs.radius) continue;
+        if(we->attrs.radius > 0 && dist > we->attrs.radius) continue;
 
         // attenuate the strength depending on the distance
         int atten = we->attrs.atten;
-        float div = max(1.0f, o.dist2(eo) * atten * WIND_ATTEN_SCALE);
+        float div = max(1.0f, dist * atten * WIND_ATTEN_SCALE);
         float speed = (we->curspeed * we->attrs.speed) / div;
 
         // vectored mode, so we're getting the direction from the yaw parameter

--- a/src/engine/wind.h
+++ b/src/engine/wind.h
@@ -43,6 +43,16 @@ struct windemitter
     void update();
 };
 
+// windprobes used for large-scale wind sampling (e.g. particles)
+struct windprobe
+{
+    int nextprobe;
+    vec lastwind;
+
+    void reset();
+    vec probe(const vec &o, const dynent *d = NULL);
+};
+
 extern int windanimdist;
 
 extern void clearwindemitters();

--- a/src/shared/cube.h
+++ b/src/shared/cube.h
@@ -58,6 +58,7 @@
 #include "command.h"
 #include "geom.h"
 #include "ents.h"
+#include "wind.h"
 
 #ifndef STANDALONE
 #include "glexts.h"

--- a/src/shared/iengine.h
+++ b/src/shared/iengine.h
@@ -282,6 +282,7 @@ struct particle
     int collide, fade, gravity, millis;
     bvec color;
     uchar flags;
+    windprobe wind;
     float size, blend;
     union
     {


### PR DESCRIPTION
This change introduces a simple method of scheduling wind probes, to avoid large slowdowns when a lot of particles and wind emitters are present in the scene.

A new timer is introduced, for measuring particle CPU load.

Also, fixes a small issue with clearing wind emitters.