### PR TITLE
bomber ball: show target's name above reticle

### DIFF
--- a/src/game/bomber.cpp
+++ b/src/game/bomber.cpp
@@ -204,6 +204,8 @@ namespace bomber
                     gle::colorf(rp, gp, bp, sq*0.5f);
                     hud::drawsized(sx+ss/4, sy+ss/4, ss/2);
                 }
+                float fade = camera1->o.distrange(e->headpos(), game::bombertargetnamefadeat*game::aboveheadnamessize, game::bombertargetnamefadecut*game::aboveheadnamessize);
+                draw_textf("%s", cx*w, cy*h-size, 0, 0, -1, -1, -1, int(255*blend*fade), TEXT_CENTERED, -1, 0, 0, game::colourname(e));
             }
         }
     }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -334,6 +334,9 @@ namespace game
     FVAR(IDF_PERSIST, affinityfollowblend, 0, 0.5f, 1);
     FVAR(IDF_PERSIST, affinitythirdblend, 0, 0.5f, 1);
 
+    FVAR(IDF_PERSIST, bombertargetnamefadeat, 0, 20, FVAR_MAX);
+    FVAR(IDF_PERSIST, bombertargetnamefadecut, 0, 15, FVAR_MAX);
+
     VAR(IDF_PERSIST, footstepsounds, 0, 3, 3); // 0 = off, &1 = focus, &2 = everyone else
     FVAR(IDF_PERSIST, footstepsoundmin, 0, 0, FVAR_MAX); // minimum velocity magnitude
     FVAR(IDF_PERSIST, footstepsoundmax, 0, 150, FVAR_MAX); // maximum velocity magnitude

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -2153,8 +2153,8 @@ namespace game
             bloodfade, bloodsize, bloodsparks, debrisfade, eventiconfade, eventiconshort, damageinteger,
             announcefilter, dynlighteffects, aboveheadaffinity, aboveheadnames, followthirdperson, nogore, forceplayermodel, forceplayerpattern,
             playerovertone, playerundertone, playerdisplaytone, playereffecttone, playerteamtone, follow, specmode, spectvfollow, spectvfollowing, clientcrc, affinityhint;
-    extern float bloodscale, debrisscale, aboveitemiconsize, playerovertonelevel, playerundertonelevel, playerdisplaytonelevel, playereffecttonelevel, playerteamtonelevel,
-            affinityhintblend, affinityhintsize, affinityhintfadeat, affinityhintfadecut, affinityfollowblend, affinitythirdblend, damagedivisor;
+    extern float bloodscale, debrisscale, aboveitemiconsize, aboveheadnamessize, playerovertonelevel, playerundertonelevel, playerdisplaytonelevel, playereffecttonelevel, playerteamtonelevel,
+    affinityhintblend, affinityhintsize, affinityhintfadeat, affinityhintfadecut, affinityfollowblend, affinitythirdblend, bombertargetnamefadeat, bombertargetnamefadecut, damagedivisor;
     extern bool zooming, wantsloadoutmenu;
     extern vec swaypush, swaydir;
     extern string clientmap;


### PR DESCRIPTION
It's hard to see the name tags on distant players, especially at the default `aboveheadnamessize`. Because of that, I often find myself accidentally passing the bomber ball to a bot instead of a human player.

This patch puts the name of the target above the reticle so you can know to whom you're about to pass the ball.

![20191122171209](https://user-images.githubusercontent.com/12238757/70243163-f9e8a600-1769-11ea-91f5-715d9e967d8e.jpg)

It fades out when you're close, disappearing roughly when the normal name tag is the same size.