### PR TITLE
fix talk command, add some helpful tips

### DIFF
--- a/config/tips.cfg
+++ b/config/tips.cfg
@@ -31,12 +31,12 @@ tipreset = [
     tipadd "You can chat with the community and developers in ^fs^fcDiscord^fS at ^fs^fcwww.redeclipse.net/discord^fS."
     tipadd "Share your own tips with the developers in ^fs^fcDiscord^fS at ^fs^fcwww.redeclipse.net/discord^fS."
     tipadd "Tips are ^fs^fccool^fS, you should ^fs^fyread them more often^fS!"
-    tipadd "When a teammate is ^fs^foon fire^fS, you can extinguish the flames by using the ^fs^fyflamer^fS secondary weapon."
-    tipadd "The ^fs^fyzoom level^fS of a scoped weapon can be adjusted by ^fs^fyscrolling^fS."
+    tipadd "When a teammate is ^fs^foon fire^fS, press ^fs^fw^f{=secondary}^fS to extinguish the flames whilst using the ^fs^fyflamer^fS."
+    tipadd "The ^fs^fyzoom level^fS of a scoped weapon can be adjusted by with ^fs^fw^f{=universaldelta 1}^fS or ^fs^fw^f{=universaldelta -1}^fS."
     tipadd "Press ^fs^fw^f{=special}^fS whilst running to quickly ^fs^fyvault^fS across ledges or small obstacles."
     tipadd "Press ^fs^fw^f{=crouch}^fS and ^fs^fw^f{=jump}^fS together whilst in mid-air to perform an ^fs^fyimpulse pound^fS."
-    tipadd "In ^fs^fybomber-ball^fS mode, you can ^fs^fypass^fS the bomb to teammates by pressing ^fs^fw^f{=affinity}^fS."
-    tipadd "Taking your own ^fs^fyflag^fS in ^fs^fycapture^fS mode will make it harder for your opponents to steal."
+    tipadd "In ^fs^fybomber-ball^fS mode, you can ^fs^fypass^fS the bomb to teammates by holding ^fs^fw^f{=affinity}^fS."
+    tipadd "Press ^fs^fw^f{=affinity}^fS to take your own ^fs^fyflag^fS in ^fs^fycapture^fS mode, making it harder for your opponents to steal."
 ]
 tipreset
 

--- a/config/tips.cfg
+++ b/config/tips.cfg
@@ -16,7 +16,7 @@ tipreset = [
     tipadd "Press ^fs^fw^f{=reload}^fS to ^fs^fyreload^fS your weapon, timing this can be crucial to survival."
     tipadd "Press ^fs^fw^f{=use}^fS to ^fs^fyuse items^fS and ^fs^fytriggers^fS."
     tipadd "Press ^fs^fw^f{=special}^fS to ^fs^fywall run^fS, ^fs^fywall kick^fS, or ^fs^fymelee^fS."
-    tipadd "Press ^fs^fw^f{=saytextcommand (getsaycolour)}^fS to ^fs^fytalk^fS and ^fs^fw^f{=sayteamcommand (getsaycolour)}^fS to only speak to ^fs^fyteammates^fS."
+    tipadd "Press ^fs^fw^f{=chat}^fS to ^fs^fytalk^fS and ^fs^fw^f{=teamchat}^fS to only speak to ^fs^fyteammates^fS."
     tipadd "Press ^fs^fw^f{=special}^fS while in the air to ^fs^fyfly-kick^fS enemies."
     tipadd "Press ^fs^fw^f{=suicide}^fS to ^fs^fysuicide^fS, this will reset you in ^fs^fyrace^fS."
     tipadd "Press ^fs^fw^f{=crouch}^fS to crouch when landing to perform an ^fs^fyimpulse slide^fS."
@@ -31,6 +31,12 @@ tipreset = [
     tipadd "You can chat with the community and developers in ^fs^fcDiscord^fS at ^fs^fcwww.redeclipse.net/discord^fS."
     tipadd "Share your own tips with the developers in ^fs^fcDiscord^fS at ^fs^fcwww.redeclipse.net/discord^fS."
     tipadd "Tips are ^fs^fccool^fS, you should ^fs^fyread them more often^fS!"
+    tipadd "When a teammate is ^fs^foon fire^fS, you can extinguish the flames by using the ^fs^fyflamer^fS secondary weapon."
+    tipadd "The ^fs^fyzoom level^fS of a scoped weapon can be adjusted by ^fs^fyscrolling^fS."
+    tipadd "Press ^fs^fw^f{=special}^fS whilst running to quickly ^fs^fyvault^fS across ledges or small obstacles."
+    tipadd "Press ^fs^fw^f{=crouch}^fS and ^fs^fw^f{=jump}^fS together whilst in mid-air to perform an ^fs^fyimpulse pound^fS."
+    tipadd "In ^fs^fybomber-ball^fS mode, you can ^fs^fypass^fS the bomb to teammates by pressing ^fs^fw^f{=affinity}^fS."
+    tipadd "Taking your own ^fs^fyflag^fS in ^fs^fycapture^fS mode will make it harder for your opponents to steal."
 ]
 tipreset
 


### PR DESCRIPTION
Changes proposed in this request:
- One of the tips doesn't display the keyboard emblems due to misnamed binds.
- Add some new helpful tips 
