### PR TITLE
Disable shadows for most dynamic lights

### DIFF
--- a/src/game/bomber.cpp
+++ b/src/game/bomber.cpp
@@ -396,7 +396,7 @@ namespace bomber
             int millis = lastmillis-f.displaytime;
             if(millis <= 1000) trans = float(millis)/1000.f;
             vec colour = isbomberaffinity(f) ? pulsecolour() : vec::fromcolor(TEAM(f.team, colour));
-            adddynlight(f.pos(true, true), enttype[AFFINITY].radius*trans, colour, 0, 0);
+            adddynlight(f.pos(true, true), enttype[AFFINITY].radius*trans, colour, 0, 0, L_NOSHADOW);
         }
     }
 
@@ -503,7 +503,7 @@ namespace bomber
                 defformatstring(text, "<huge>\fzuw%s", str);
                 part_textcopy(vec(from).add(vec(0, 0, enttype[AFFINITY].radius)), text, PART_TEXT, game::eventiconfade, TEAM(team, colour), 3, 1, -10);
             }
-            if(game::dynlighteffects) adddynlight(vec(from).add(vec(0, 0, enttype[AFFINITY].radius)), enttype[AFFINITY].radius*2, vec::fromcolor(TEAM(team, colour)).mul(2.f), 500, 250);
+            if(game::dynlighteffects) adddynlight(vec(from).add(vec(0, 0, enttype[AFFINITY].radius)), enttype[AFFINITY].radius*2, vec::fromcolor(TEAM(team, colour)).mul(2.f), 500, 250, L_NOSHADOW);
         }
         if(to.x >= 0)
         {
@@ -512,7 +512,7 @@ namespace bomber
                 defformatstring(text, "<huge>\fzuw%s", str);
                 part_textcopy(vec(to).add(vec(0, 0, enttype[AFFINITY].radius)), text, PART_TEXT, game::eventiconfade, TEAM(team, colour), 3, 1, -10);
             }
-            if(game::dynlighteffects) adddynlight(vec(to).add(vec(0, 0, enttype[AFFINITY].radius)), enttype[AFFINITY].radius*2, vec::fromcolor(TEAM(team, colour)).mul(2.f), 500, 250);
+            if(game::dynlighteffects) adddynlight(vec(to).add(vec(0, 0, enttype[AFFINITY].radius)), enttype[AFFINITY].radius*2, vec::fromcolor(TEAM(team, colour)).mul(2.f), 500, 250, L_NOSHADOW);
         }
         if(from.x >= 0 && to.x >= 0 && from != to) part_trail(PART_SPARK, 500, from, to, TEAM(team, colour), 1, 1, -10);
     }

--- a/src/game/capture.cpp
+++ b/src/game/capture.cpp
@@ -359,8 +359,8 @@ namespace capture
         {
             capturestate::flag &f = st.flags[i];
             if(f.owner || f.droptime)
-                adddynlight(vec(f.spawnloc).add(vec(0, 0, enttype[AFFINITY].radius/2)), enttype[AFFINITY].radius, vec::fromcolor(TEAM(f.team, colour)), 0, 0);
-            adddynlight(vec(f.pos(true)).add(vec(0, 0, enttype[AFFINITY].radius/2)), enttype[AFFINITY].radius, vec::fromcolor(TEAM(f.team, colour)), 0, 0);
+                adddynlight(vec(f.spawnloc).add(vec(0, 0, enttype[AFFINITY].radius/2)), enttype[AFFINITY].radius, vec::fromcolor(TEAM(f.team, colour)), 0, 0, L_NOSHADOW);
+            adddynlight(vec(f.pos(true)).add(vec(0, 0, enttype[AFFINITY].radius/2)), enttype[AFFINITY].radius, vec::fromcolor(TEAM(f.team, colour)), 0, 0, L_NOSHADOW);
         }
     }
 
@@ -461,7 +461,7 @@ namespace capture
                 defformatstring(text, "<huge>\fzuw%s", str);
                 part_textcopy(vec(from).add(vec(0, 0, enttype[AFFINITY].radius)), text, PART_TEXT, game::eventiconfade, TEAM(team, colour), 3, 1, -10);
             }
-            if(game::dynlighteffects) adddynlight(vec(from).add(vec(0, 0, enttype[AFFINITY].radius)), enttype[AFFINITY].radius*2, vec::fromcolor(TEAM(team, colour)).mul(2.f), 500, 250);
+            if(game::dynlighteffects) adddynlight(vec(from).add(vec(0, 0, enttype[AFFINITY].radius)), enttype[AFFINITY].radius*2, vec::fromcolor(TEAM(team, colour)).mul(2.f), 500, 250, L_NOSHADOW);
         }
         if(to.x >= 0)
         {
@@ -470,7 +470,7 @@ namespace capture
                 defformatstring(text, "<huge>\fzuw%s",str);
                 part_textcopy(vec(to).add(vec(0, 0, enttype[AFFINITY].radius)), text, PART_TEXT, game::eventiconfade, TEAM(team, colour), 3, 1, -10);
             }
-            if(game::dynlighteffects) adddynlight(vec(to).add(vec(0, 0, enttype[AFFINITY].radius)), enttype[AFFINITY].radius*2, vec::fromcolor(TEAM(team, colour)).mul(2.f), 500, 250);
+            if(game::dynlighteffects) adddynlight(vec(to).add(vec(0, 0, enttype[AFFINITY].radius)), enttype[AFFINITY].radius*2, vec::fromcolor(TEAM(team, colour)).mul(2.f), 500, 250, L_NOSHADOW);
         }
         if(from.x >= 0 && to.x >= 0 && from != to) part_trail(PART_SPARK, 500, from, to, TEAM(team, colour), 1, 1, -10);
     }

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -2977,7 +2977,7 @@ namespace client
                             }
                         }
                         game::spawneffect(PART_SPARK, e.o, enttype[e.type].radius*0.25f, colour, 1);
-                        if(game::dynlighteffects) adddynlight(e.o, enttype[e.type].radius, vec::fromcolor(colour).mul(2.f), 250, 250);
+                        if(game::dynlighteffects) adddynlight(e.o, enttype[e.type].radius, vec::fromcolor(colour).mul(2.f), 250, 250, L_NOSHADOW);
                     }
                     break;
                 }

--- a/src/game/defend.cpp
+++ b/src/game/defend.cpp
@@ -178,7 +178,7 @@ namespace defend
         {
             defendstate::flag &f = st.flags[i];
             float occupy = f.occupied(m_dac_quick(game::gamemode, game::mutators), defendcount);
-            adddynlight(vec(f.o).add(vec(0, 0, enttype[AFFINITY].radius)), enttype[AFFINITY].radius*2, skewcolour(f.owner, f.enemy, occupy), 0, 0);
+            adddynlight(vec(f.o).add(vec(0, 0, enttype[AFFINITY].radius)), enttype[AFFINITY].radius*2, skewcolour(f.owner, f.enemy, occupy), 0, 0, L_NOSHADOW);
         }
     }
 
@@ -342,7 +342,7 @@ namespace defend
                         if((d = e) == game::focus) break;
                     game::announcef(S_V_FLAGSECURED, CON_EVENT, d, true, "\faTeam %s secured \fw\f($pointtex)%s", game::colourteam(owner), b.name);
                     if(game::aboveheadaffinity) part_textcopy(vec(b.o).add(vec(0, 0, enttype[AFFINITY].radius)), "<huge>\fzuwSECURED", PART_TEXT, game::eventiconfade, TEAM(owner, colour), 3, 1, -10);
-                    if(game::dynlighteffects) adddynlight(b.o, enttype[AFFINITY].radius*2, vec::fromcolor(TEAM(owner, colour)).mul(2.f), 500, 250);
+                    if(game::dynlighteffects) adddynlight(b.o, enttype[AFFINITY].radius*2, vec::fromcolor(TEAM(owner, colour)).mul(2.f), 500, 250, L_NOSHADOW);
                 }
             }
             else if(b.owner)
@@ -353,7 +353,7 @@ namespace defend
                     if((d = e) == game::focus) break;
                 game::announcef(S_V_FLAGOVERTHROWN, CON_EVENT, d, true, "\faTeam %s overthrew \fw\f($pointtex)%s", game::colourteam(enemy), b.name);
                 if(game::aboveheadaffinity) part_textcopy(vec(b.o).add(vec(0, 0, enttype[AFFINITY].radius)), "<huge>\fzuwOVERTHROWN", PART_TEXT, game::eventiconfade, TEAM(enemy, colour), 3, 1, -10);
-                if(game::dynlighteffects) adddynlight(b.o, enttype[AFFINITY].radius*2, vec::fromcolor(TEAM(enemy, colour)).mul(2.f), 500, 250);
+                if(game::dynlighteffects) adddynlight(b.o, enttype[AFFINITY].radius*2, vec::fromcolor(TEAM(enemy, colour)).mul(2.f), 500, 250, L_NOSHADOW);
             }
             b.converted = converted;
         }

--- a/src/game/entities.cpp
+++ b/src/game/entities.cpp
@@ -488,7 +488,7 @@ namespace entities
         }
         d->useitem(ent, e.type, attr, ammoamt, sweap, lastmillis, W(attr, delayitem));
         playsound(e.type == WEAPON && attr >= W_OFFSET && attr < W_ALL ? WSND(attr, S_W_USE) : S_ITEMUSE, d->o, d, 0, -1, -1, -1, &d->wschan[WS_MAIN_CHAN]);
-        if(game::dynlighteffects) adddynlight(d->center(), enttype[e.type].radius*2, vec::fromcolor(colour).mul(2.f), 250, 250);
+        if(game::dynlighteffects) adddynlight(d->center(), enttype[e.type].radius*2, vec::fromcolor(colour).mul(2.f), 250, 250, L_NOSHADOW);
         if(ents.inrange(drop) && ents[drop]->type == WEAPON)
         {
             gameentity &f = *(gameentity *)ents[drop];

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -930,7 +930,7 @@ namespace game
             playsound(S_RESPAWN, d->o, d);
             spawneffect(PART_SPARK, center, d->height*0.5f, getcolour(d, playerovertone, playerovertonelevel), 1);
             spawneffect(PART_SPARK, center, d->height*0.5f, getcolour(d, playerundertone, playerundertonelevel), 1);
-            if(dynlighteffects) adddynlight(center, d->height*2, vec::fromcolor(getcolour(d, playereffecttone, playereffecttonelevel)).mul(2.f), 250, 250);
+            if(dynlighteffects) adddynlight(center, d->height*2, vec::fromcolor(getcolour(d, playereffecttone, playereffecttonelevel)).mul(2.f), 250, 250, L_NOSHADOW);
             if(entities::ents.inrange(ent) && entities::ents[ent]->type == PLAYERSTART) entities::execlink(d, ent, false);
         }
         ai::respawned(d, local, ent);
@@ -1011,14 +1011,14 @@ namespace game
                 if(d->weapselect == W_FLAMER && (!reloading || amt > 0.5f) && !physics::liquidcheck(d))
                 {
                     float scale = powering ? 1.f+(amt*1.5f) : (d->weapstate[d->weapselect] == W_S_IDLE ? 1.f : (reloading ? (amt-0.5f)*2 : amt));
-                    adddynlight(d->ejecttag(d->weapselect), 16*scale, col, 0, 0);
+                    adddynlight(d->ejecttag(d->weapselect), 16*scale, col, 0, 0, L_NOSHADOW);
                 }
                 if((W(d->weapselect, lightpersist)&1 || powering) && W(d->weapselect, lightradius) > 0)
                 {
                     float thresh = max(amt, 0.25f), size = W(d->weapselect, lightradius)*thresh;
                     int span = max(W2(d->weapselect, cooktime, physics::secondaryweap(d))/4, 500), interval = lastmillis%span, part = span/2;
                     if(interval) size += size*0.5f*(interval <= part ? interval/float(part) : (span-interval)/float(part));
-                    adddynlight(d->muzzletag(d->weapselect), size, vec(col).mul(thresh), 0, 0);
+                    adddynlight(d->muzzletag(d->weapselect), size, vec(col).mul(thresh), 0, 0, L_NOSHADOW);
                 }
             }
             if(d->burntime && d->burning(lastmillis, d->burntime))
@@ -1033,7 +1033,7 @@ namespace game
                     if(fluc >= 0.25f) fluc = (0.25f+0.03f-fluc)*(0.25f/0.03f);
                     pc *= 0.75f+fluc;
                 }
-                adddynlight(d->center(), d->height*intensity*pc, pulsecolour(d).mul(pc), 0, 0);
+                adddynlight(d->center(), d->height*intensity*pc, pulsecolour(d).mul(pc), 0, 0, L_NOSHADOW);
             }
             if(d->shocktime && d->shocking(lastmillis, d->shocktime))
             {
@@ -1047,10 +1047,10 @@ namespace game
                     if(fluc >= 0.25f) fluc = (0.25f+0.03f-fluc)*(0.25f/0.03f);
                     pc *= 0.75f+fluc;
                 }
-                adddynlight(d->center(), d->height*intensity*pc, pulsecolour(d, PULSE_SHOCK).mul(pc), 0, 0);
+                adddynlight(d->center(), d->height*intensity*pc, pulsecolour(d, PULSE_SHOCK).mul(pc), 0, 0, L_NOSHADOW);
             }
             if(d->actortype < A_ENEMY && illumlevel > 0 && illumradius > 0)
-                adddynlight(d->center(), illumradius, vec::fromcolor(getcolour(d, playereffecttone, illumlevel)), 0, 0);
+                adddynlight(d->center(), illumradius, vec::fromcolor(getcolour(d, playereffecttone, illumlevel)), 0, 0, L_NOSHADOW);
         }
     }
 

--- a/src/game/projs.cpp
+++ b/src/game/projs.cpp
@@ -286,7 +286,7 @@ namespace projs
                 case W_RIFLE:
                     part_splash(PART_SPARK, proj.child ? 5 : 10, proj.child ? 250 : 500, proj.o, FWCOL(H, partcol, proj), WF(WK(proj.flags), proj.weap, partsize, WS(proj.flags))*proj.curscale*0.125f, 1, 1, 0, 24, 20);
                     part_create(PART_PLASMA, proj.child ? 250 : 500, proj.o, FWCOL(H, partcol, proj), expl*0.5f, 0.5f, 0, 0);
-                    adddynlight(proj.o, expl*1.1f, FWCOL(P, partcol, proj), 250, 10);
+                    adddynlight(proj.o, expl*1.1f, FWCOL(P, partcol, proj), 250, 10, L_NOSHADOW);
                     break;
                 default:
                     if(WF(WK(proj.flags), proj.weap, collide, WS(proj.flags))&COLLIDE_LENGTH)
@@ -1265,7 +1265,7 @@ namespace projs
                 part_flare(orig, targ, delayattack/2, PART_MUZZLE_FLARE, colour, weapfx[weap].flaresize, muz, 0, 0, d);
             }
             int peak = delayattack/4, fade = min(peak/2, 75);
-            adddynlight(orig, 32, vec::fromcolor(colour).mul(0.5f), fade, peak - fade, DL_FLASH);
+            adddynlight(orig, 32, vec::fromcolor(colour).mul(0.5f), fade, peak - fade, L_NOSHADOW | DL_FLASH);
         }
         loopv(shots)
             create(orig, vec(shots[i].pos).div(DMF), local, d, PRJ_SHOT, weap, flags, max(life, 1), W2(weap, time, WS(flags)), delay+(iter*i), speed, shots[i].id, weap, -1, flags, skew, false, v);
@@ -1659,7 +1659,7 @@ namespace projs
                             if(WF(WK(proj.flags), proj.weap, wavepush, WS(proj.flags)) >= 1)
                                 part_explosion(proj.o, expl*0.5f*WF(WK(proj.flags), proj.weap, wavepush, WS(proj.flags)), PART_SHOCKWAVE, halflen, projhint(proj.owner, FWCOL(H, explcol, proj)), 1.f, 0.5f*WF(WK(proj.flags), proj.weap, partblend, WS(proj.flags))*projhintblend);
                             addstain(STAIN_SCORCH_SHORT, proj.o, proj.norm, expl*0.5f);
-                            adddynlight(proj.o, expl, FWCOL(P, explcol, proj), len, 10);
+                            adddynlight(proj.o, expl, FWCOL(P, explcol, proj), len, 10, L_NOSHADOW);
                         }
                         else addstain(STAIN_BULLET, proj.o, proj.norm, max(WF(WK(proj.flags), proj.weap, partsize, WS(proj.flags)), 0.25f)*4);
                         break;
@@ -1694,7 +1694,7 @@ namespace projs
                             part_create(PART_FIREBALL_SOFT, len*2, to, FWCOL(H, explcol, proj), expl*1.25f, (0.5f+(rnd(50)/100.f))*WF(WK(proj.flags), proj.weap, partblend, WS(proj.flags)), -10);
                         }
                         addstain(type == W_FLAMER ? STAIN_SCORCH_SHORT : STAIN_SCORCH, proj.o, proj.norm, expl*0.5f);
-                        adddynlight(proj.o, expl, FWCOL(P, explcol, proj), len, 10);
+                        adddynlight(proj.o, expl, FWCOL(P, explcol, proj), len, 10, L_NOSHADOW);
                         break;
                     }
                     case W_SHOTGUN: case W_SMG:
@@ -1708,7 +1708,7 @@ namespace projs
                             if(WF(WK(proj.flags), proj.weap, wavepush, WS(proj.flags)) >= 1)
                                 part_explosion(proj.o, expl*0.5f*WF(WK(proj.flags), proj.weap, wavepush, WS(proj.flags)), PART_SHOCKWAVE, halflen, projhint(proj.owner, FWCOL(H, explcol, proj)), 1.f, 0.5f*WF(WK(proj.flags), proj.weap, partblend, WS(proj.flags))*projhintblend);
                             addstain(STAIN_SCORCH_SHORT, proj.o, proj.norm, expl*0.5f);
-                            adddynlight(proj.o, expl, FWCOL(P, explcol, proj), len, 10);
+                            adddynlight(proj.o, expl, FWCOL(P, explcol, proj), len, 10, L_NOSHADOW);
                         }
                         else addstain(STAIN_BULLET, proj.o, proj.norm, max(WF(WK(proj.flags), proj.weap, partsize, WS(proj.flags)), 0.25f)*4);
                         break;
@@ -1728,7 +1728,7 @@ namespace projs
                         part_create(PART_ELECTRIC_SOFT, halflen, proj.o, FWCOL(H, partcol, proj), expl*0.375f, WF(WK(proj.flags), proj.weap, partblend, WS(proj.flags)));
                         part_create(PART_SMOKE, len, proj.o, FWCOL(H, partcol, proj), expl*0.35f, 0.35f*WF(WK(proj.flags), proj.weap, partblend, WS(proj.flags)), -30);
                         addstain(STAIN_ENERGY, proj.o, proj.norm, expl*0.75f, bvec::fromcolor(FWCOL(P, explcol, proj)));
-                        adddynlight(proj.o, 1.1f*expl, FWCOL(P, explcol, proj), len, 10);
+                        adddynlight(proj.o, 1.1f*expl, FWCOL(P, explcol, proj), len, 10, L_NOSHADOW);
                         break;
                     }
                     case W_RIFLE: case W_ZAPPER:
@@ -1746,7 +1746,7 @@ namespace projs
                         if(projhints) part_flare(proj.trailpos, proj.o, len, type != W_ZAPPER ? PART_FLARE : PART_LIGHTZAP_FLARE, projhint(proj.owner, FWCOL(H, partcol, proj)), WF(WK(proj.flags), proj.weap, partsize, WS(proj.flags))*projhintsize*proj.curscale, projhintblend*WF(WK(proj.flags), proj.weap, partblend, WS(proj.flags)));
                         addstain(STAIN_SCORCH, proj.o, proj.norm, max(expl, 2.f));
                         addstain(STAIN_ENERGY, proj.o, proj.norm, max(expl*0.5f, 1.f), bvec::fromcolor(FWCOL(P, explcol, proj)));
-                        adddynlight(proj.o, 1.1f*expl, FWCOL(P, explcol, proj), len, 10);
+                        adddynlight(proj.o, 1.1f*expl, FWCOL(P, explcol, proj), len, 10, L_NOSHADOW);
                         break;
                     }
                     default: break;
@@ -2621,14 +2621,14 @@ namespace projs
             int type = WF(WK(proj.flags), proj.weap, parttype, WS(proj.flags));
             if(trans > 0) switch(type)
             {
-                case W_CLAW: case W_SWORD: adddynlight(proj.o, 24*trans, FWCOL(P, partcol, proj)); break;
+                case W_CLAW: case W_SWORD: adddynlight(proj.o, 24*trans, FWCOL(P, partcol, proj), 0, 0, L_NOSHADOW); break;
                 case W_PISTOL: case W_SHOTGUN: case W_SMG: case W_ZAPPER: case W_RIFLE:
                 {
                     float expl = WX(WK(proj.flags), proj.weap, radial, WS(proj.flags), game::gamemode, game::mutators, proj.curscale*proj.lifesize);
                     if(type != W_ZAPPER || expl <= 0)
                     {
                         float size = clamp(WF(WK(proj.flags), proj.weap, partlen, WS(proj.flags))*(1.f-proj.lifespan)*proj.curscale, proj.curscale, min(16.f, min(WF(WK(proj.flags), proj.weap, partlen, WS(proj.flags)), proj.o.dist(proj.from))));
-                        adddynlight(proj.o, 1.25f*size*trans, FWCOL(P, partcol, proj));
+                        adddynlight(proj.o, 1.25f*size*trans, FWCOL(P, partcol, proj), 0, 0, L_NOSHADOW);
                         break;
                     }
                 }
@@ -2636,7 +2636,8 @@ namespace projs
                 {
                     float size = WX(WK(proj.flags), proj.weap, radial, WS(proj.flags), game::gamemode, game::mutators, proj.curscale*proj.lifesize);
                     if(size <= 0) size = WF(WK(proj.flags), proj.weap, partlen, WS(proj.flags))*proj.lifesize*proj.curscale*0.5f;
-                    adddynlight(proj.o, 1.5f*size*trans, FWCOL(P, partcol, proj));
+                    // Enable shadows only for grenades, as they cast a large light and can move slowly
+                    adddynlight(proj.o, 1.5f*size*trans, FWCOL(P, partcol, proj), 0, 0, type == W_GRENADE ? 0 : L_NOSHADOW);
                     break;
                 }
                 default: break;


### PR DESCRIPTION
Most dynamic lights are small and only last for a short time, so it makes sense to disable shadows for better performance.

Moreover, this prevents some dynamic light effects from intersecting with the first-person/third-person player models, which can look bad.

Feel free to review the list of dynamic lights I tweaked. Maybe we could leave them enabled for DAC bases, but I'm not entirely sure. The fact you can see DAC base lights through thin walls can be beneficial to gameplay, even if it's technically incorrect.