### PR TITLE
Improve the display of default/modified variables in the console

### DIFF
--- a/config/ui/console.cfg
+++ b/config/ui/console.cfg
@@ -144,25 +144,45 @@ ui_console_usage_text = [
         if (& $idflags $idfbithex) [
             if (= (getvarmax $idname) 0xFFFFFF) [
                 uitext (format "^faMin: ^fw%1^fa, Max: ^fw%2" (ui_console_colour_var (getvarmin $idname)) (ui_console_colour_var (getvarmax $idname))) $ui_textstatus $textstyle
-                uitext (format "^faDefault: ^fw%1^fa, Current: ^fw%2^fa [^fs^f[%3]#^fS]" (ui_console_colour_var (getvardef $idname)) (ui_console_colour_var $$idname) $$idname) $ui_textstatus $textstyle
+                if (= (getvardef $idname) $$idname) [
+                    uitext (format "^faCurrent: ^fw%1^fa [^fs^f[%2]#^fS] ^fa(default)" (ui_console_colour_var (getvardef $idname)) $$idname) $ui_textstatus $textstyle
+                ] [
+                    uitext (format "^faDefault: ^fw%1^fa, Current: ^fy%2^fa [^fs^f[%3]#^fS]" (ui_console_colour_var (getvardef $idname)) (ui_console_colour_var $$idname) $$idname) $ui_textstatus $textstyle
+                ]
             ] [
                 uitext (format "^faMin: ^fw%1^fa, Max: ^fw%2" (tohex (getvarmin $idname)) (tohex (getvarmax $idname))) $ui_textstatus $textstyle
-                uitext (format "^faDefault: ^fw%1^fa, Current: ^fw%2" (tohex (getvardef $idname)) (tohex $$idname)) $ui_textstatus $textstyle
+                if (= (getvardef $idname) $$idname) [
+                    uitext (format "^faCurrent: ^fw%1 ^fa(default)" (tohex (getvardef $idname))) $ui_textstatus $textstyle
+                ] [
+                    uitext (format "^faDefault: ^fw%1^fa, Current: ^fy%2" (tohex (getvardef $idname)) (tohex $$idname)) $ui_textstatus $textstyle
+                ]
             ]
         ] [
             uitext (format "^faMin: ^fw%1^fa, Max: ^fw%2" (getvarmin $idname) (getvarmax $idname)) $ui_textstatus $textstyle
-            uitext (format "^faDefault: ^fw%1^fa, Current: ^fw%2" (getvardef $idname) $$idname) $ui_textstatus $textstyle
+            if (= (getvardef $idname) $$idname) [
+                uitext (format "^faCurrent: ^fw%1 ^fa(default)" (getvardef $idname)) $ui_textstatus $textstyle
+            ] [
+                uitext (format "^faDefault: ^fw%1^fa, Current: ^fy%2" (getvardef $idname) $$idname) $ui_textstatus $textstyle
+            ]
         ]
     ] $ididxfvar [
         uitext (format "^faMin: ^fw%1^fa, Max: ^fw%2" (getfvarmin $idname) (getfvarmax $idname)) $ui_textstatus $textstyle
-        uitext (format "^faDefault: ^fw%1^fa, Current: ^fw%2" (getfvardef $idname) $$idname) $ui_textstatus $textstyle
+        if (= (getfvardef $idname) $$idname) [
+            uitext (format "^faCurrent: ^fw%1 ^fa(default)" (getfvardef $idname)) $ui_textstatus $textstyle
+        ] [
+            uitext (format "^faDefault: ^fw%1^fa, Current: ^fy%2" (getfvardef $idname) $$idname) $ui_textstatus $textstyle
+        ]
     ] $ididxsvar [
-        uitext (format "^faDefault: ^fw%1^fa, Current: ^fw%2" (getsvardef $idname) $$idname) $ui_textstatus $textstyle
+        if (= (getsvardef $idname) $$idname) [
+            uitext (format "^faCurrent: ^fw%1 ^fa(default)" (getsvardef $idname)) $ui_textstatus $textstyle
+        ] [
+            uitext (format "^faDefault: ^fw%1^fa, Current: ^fy%2" (getsvardef $idname) $$idname) $ui_textstatus $textstyle
+        ]
     ] $ididxcommand [
         if (strlen (getvarargs $idname)) [
-            uitext (format "^faArgs: ^fw%1 ^fa(^fw%2^fa)" (strlen (getvarargs $idname)) (getvarargs $idname)) $ui_textstatus $textstyle
+            uitext (format "^faArguments: ^fw%1 ^fa(^fw%2^fa)" (strlen (getvarargs $idname)) (getvarargs $idname)) $ui_textstatus $textstyle
         ] [
-            uitext "^fAargs: ^fwnone" $ui_textstatus $textstyle
+            uitext "^fAArguments: ^fwnone" $ui_textstatus $textstyle
         ]
     ]
 


### PR DESCRIPTION
This makes modified values easier to distinguish at a quick glance, thanks to their yellow color.

Default values are now merged with the current value when the current value is the default one.

## Preview

![Default value](https://user-images.githubusercontent.com/180032/71489888-39b22300-2828-11ea-9930-9a7f324260ba.png)

![Custom value](https://user-images.githubusercontent.com/180032/71489886-374fc900-2828-11ea-9664-0fd18a2a02cc.png)