### PR TITLE
Print the modified map CRC message only when the map CRC differs

### DIFF
--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -6332,8 +6332,8 @@ namespace server
                     ci->wantsmap = ci->gettingmap = false;
                     if(!m_edit(gamemode))
                     {
-                        if(hasmapdata()) srvoutf(4, "\fy%s has map crc: \fs\fc0x%.8x\fS (server: \fs\fc0x%.8x\fS)", colourname(ci), ci->clientcrc, smapcrc);
-                        else srvoutf(4, "\fy%s has map crc: \fs\fc0x%.8x\fS", colourname(ci), ci->clientcrc);
+                        if(hasmapdata() && ci->clientcrc != smapcrc) srvoutf(4, "\fy%s has a modified map (CRC \fs\fc0x%.8x\fS, server has \fs\fc0x%.8x\fS)", colourname(ci), ci->clientcrc, smapcrc);
+                        else srvoutf(4, "\fy%s has map CRC: \fs\fc0x%.8x\fS", colourname(ci), ci->clientcrc);
                     }
                     if(crclocked(ci, true)) getmap(ci);
                     if(ci->isready()) aiman::poke();


### PR DESCRIPTION
This reduces noise in the console when many players join a server.