### PR TITLE
Don't display the `/0` ammo store on the HUD for grenades/rockets/mines

### DIFF
--- a/config/ui/hud.cfg
+++ b/config/ui/hud.cfg
@@ -707,11 +707,21 @@ ui_hud_weapdisplay = [
                 uiimage $[@[ui_hud_weapidx]tex] $ui_hud_weapcol 0 $ui_hud_barw $ui_hud_barw [uialign 0 0]
                 caseif (& (= $[@[ui_hud_weapidx]ammosub1] 0) (= $[@[ui_hud_weapidx]ammosub2] 0)) [ //if ammosub is 0 for both primary/secondary, display inf ammo
                     uitext "8" $ui_text [uitextlimit 1; uialign 0 1; uitextrotate 1]
-                ] (& (<=f $ui_hud_weappart 0.25) (!= $[@[ui_hud_weapidx]ammostore] 0) ) [ //if ammo is below 25% max and weapon has limited ammo (ammostore != 0) pulse warning colors
-                    uitext (concatword $ui_hud_weapammo "/" $ui_hud_weapstore) $ui_text [uitextlimit 1; uicolourset (getclientrescolour $ui_hud_focus $pulseidxwarn); uialign 0 1]
+                ] (& (<=f $ui_hud_weappart 0.25) (!= $[@[ui_hud_weapidx]ammostore] -1) ) [ //if ammo is below 25% max and weapon has limited ammo (ammostore != 0) pulse warning colors
+                    if (= $[@[ui_hud_weapidx]ammostore] 0) [
+                        //collectible weapon (rocket, grenade, mine), don't display ammo in storage
+                        uitext $ui_hud_weapammo $ui_text [uitextlimit 1; uicolourset (getclientrescolour $ui_hud_focus $pulseidxwarn); uialign 0 1]
+                    ] [
+                       uitext (concatword $ui_hud_weapammo "/" $ui_hud_weapstore) $ui_text [uitextlimit 1; uicolourset (getclientrescolour $ui_hud_focus $pulseidxwarn); uialign 0 1]
+                    ]
                 ] () [
-                    if ( || (= $[@[ui_hud_weapidx]ammoitem] 1) (!= $[@[ui_hud_weapidx]ammostore] 0)) [ //if weapon has ammocap or only picks up 1 ammo per pickup (rocket, grenade, mine), display ammo in gun + ammo in storage
-                        uitext (concatword $ui_hud_weapammo "/" $ui_hud_weapstore) $ui_text [uitextlimit 1; uialign 0 1]
+                    if ( || (= $[@[ui_hud_weapidx]ammoitem] 1) (!= $[@[ui_hud_weapidx]ammostore] -1)) [ //if weapon has ammocap, display ammo in gun + ammo in storage
+                        if (= $[@[ui_hud_weapidx]ammostore] 0) [
+                            //collectible weapon (rocket, grenade, mine), don't display ammo in storage
+                            uitext $ui_hud_weapammo $ui_text [uitextlimit 1; uialign 0 1]
+                        ] [
+                            uitext (concatword $ui_hud_weapammo "/" $ui_hud_weapstore) $ui_text [uitextlimit 1; uialign 0 1]
+                        ]
                     ] [ //else display ammo in gun and infinity for ammo in storage
                         uihlist -.007 [ //magic number to help align rotated "8"
                             uitextright (concatword $ui_hud_weapammo "/") $ui_text [uitextlimit 1; uialign 0 1]


### PR DESCRIPTION
This also fixes the "infinite ammo store" condition to make the pistol HUD display correct again.

## Preview

![Grenade](https://user-images.githubusercontent.com/180032/71564010-910afa00-2a99-11ea-99f6-c66b7794cec5.png)

![Pistol](https://user-images.githubusercontent.com/180032/71564015-95cfae00-2a99-11ea-854e-2f3fae7ee235.png)