### PR TITLE
generalize architecture handling a little

### DIFF
--- a/redeclipse.sh
+++ b/redeclipse.sh
@@ -51,11 +51,20 @@ redeclipse_setup() {
             i486|i586|i686|x86)
                 REDECLIPSE_ARCH="x86"
                 ;;
+            ppc64*|powerpc64*)
+                REDECLIPSE_ARCH="ppc64"
+                ;;
+            ppc*|powerpc*)
+                REDECLIPSE_ARCH="ppc"
+                ;;
             x86_64|[Aa][Mm][Dd]64)
                 REDECLIPSE_ARCH="amd64"
                 ;;
             arm|armv*)
                 REDECLIPSE_ARCH="arm"
+                ;;
+            aarch64*)
+                REDECLIPSE_ARCH="aarch64"
                 ;;
             *)
                 REDECLIPSE_ARCH="native"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,7 +62,11 @@ endif()
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 # set compile options
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fsigned-char -ffast-math -fno-exceptions -fno-rtti -Wno-invalid-offsetof")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fsigned-char -fno-exceptions -fno-rtti -Wno-invalid-offsetof")
+
+if(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "i[3-6]86|x86_64")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffast-math")
+endif()
 
 # Use pkg-config to configure dependencies later
 find_package(PkgConfig REQUIRED)
@@ -267,6 +271,14 @@ if(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "i[3-6]86")
 	set(ARCHITECTURE "x86")
 elseif(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "x86_64")
 	set(ARCHITECTURE "amd64")
+elseif(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "ppc64*")
+	set(ARCHITECTURE "ppc64")
+elseif(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "ppc|powerpc")
+	set(ARCHITECTURE "ppc")
+elseif(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "armv*")
+	set(ARCHITECTURE "arm")
+elseif(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "aarch64")
+	set(ARCHITECTURE "aarch64")
 else()
     set(ARCHITECTURE "native")
 endif()

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,9 +2,6 @@ APPNAME=redeclipse
 APPCLIENT=$(APPNAME)
 APPSERVER=$(APPNAME)_server
 
-#CXXFLAGS= -ggdb3
-CXXFLAGS?= -O3 -fomit-frame-pointer -ffast-math
-override CXXFLAGS+= -Wall -fsigned-char -fno-exceptions -fno-rtti -Wno-invalid-offsetof
 PLATFORM= $(shell $(CC) -dumpmachine)
 RMFLAGS= -fv
 PKG_CONFIG ?= pkg-config
@@ -19,17 +16,15 @@ ifeq (,$(PLATFORM_REVISION))
 PLATFORM_REVISION=""
 endif
 
-ifeq (,$(PLATFORM_BIN))
-ifneq (,$(findstring arm,$(PLATFORM)))
-PLATFORM_BIN=arm
+PLATFORM_BIN?=$(shell ./get_binarch.sh $(PLATFORM))
+
+#CXXFLAGS= -ggdb3
+ifneq (,$(filter amd64 x86,$(PLATFORM_BIN)))
+CXXFLAGS?= -O3 -fomit-frame-pointer -ffast-math
 else
-ifneq (,$(findstring 64,$(PLATFORM)))
-PLATFORM_BIN=amd64
-else
-PLATFORM_BIN=x86
+CXXFLAGS?= -O3 -fomit-frame-pointer
 endif
-endif
-endif
+override CXXFLAGS+= -Wall -fsigned-char -fno-exceptions -fno-rtti -Wno-invalid-offsetof
 
 ifeq (,$(INSTDIR))
 INSTDIR=../bin/$(PLATFORM_BIN)
@@ -59,7 +54,7 @@ ifneq (,$(WANT_DISCORD))
 ifneq (,$(findstring mingw,$(PLATFORM)))
 override INCLUDES+= -DUSE_DISCORD=1
 else
-ifneq (,$(findstring 64,$(PLATFORM)))
+ifneq (,$(findstring x86_64,$(PLATFORM)))
 override INCLUDES+= -DUSE_DISCORD=1
 endif
 endif
@@ -89,7 +84,7 @@ override WINDRES=$(TOOLSET_PREFIX)$(WINDRES_TEMP)
 STD_LIBS= -static-libgcc -static-libstdc++
 CLIENT_INCLUDES= $(INCLUDES) -Iinclude
 CLIENT_LIBS= -mwindows $(STD_LIBS) -L$(WINDLL) -L$(WINLIB) -lSDL2 -lSDL2_image -lSDL2_mixer -lzlib1 -lopengl32 -lenet -lws2_32 -lwinmm
-ifneq (,$(findstring 64,$(PLATFORM)))
+ifneq (,$(findstring x86_64,$(PLATFORM)))
 override WINDRES+= -F pe-x86-64
 ifneq (,$(WANT_STEAM))
 override CLIENT_LIBS+= -lsteam_api64
@@ -123,7 +118,7 @@ ifneq (,$(WANT_STEAM))
 override CLIENT_LIBS+= -L../bin/$(PLATFORM_BIN) -lsteam_api
 endif
 ifneq (,$(WANT_DISCORD))
-ifneq (,$(findstring 64,$(PLATFORM)))
+ifneq (,$(findstring x86_64,$(PLATFORM)))
 override CLIENT_LIBS+= -L../bin/$(PLATFORM_BIN) -ldiscord-rpc
 endif
 endif
@@ -208,7 +203,7 @@ SERVER_LIBS= -mwindows $(STD_LIBS) -L$(WINDLL) -L$(WINLIB) -lzlib1 -lenet -lws2_
 CTFONT_INCLUDES= -DSTANDALONE -Iinclude
 CTFONT_LIBS= -mwindows $(STD_LIBS) -L$(WINDLL) -L$(WINLIB) -lzlib1 -lfreetype
 ifneq (,$(WANT_STEAM))
-ifneq (,$(findstring 64,$(PLATFORM)))
+ifneq (,$(findstring x86_64,$(PLATFORM)))
 override SERVER_LIBS+= -lsteam_api64
 else
 override SERVER_LIBS+= -lsteam_api

--- a/src/get_binarch.sh
+++ b/src/get_binarch.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# given a target triple, prints the binary architecture name
+
+case $1 in
+    x86_64*)    echo amd64;;
+    i[4-6]86*)  echo x86;;
+    armv*)      echo arm;;
+    aarch64*)   echo aarch64;;
+    powerpc64*) echo ppc64;;
+    powerpc*)   echo ppc;;
+    *) ;; # unknown
+esac
+
+exit 0


### PR DESCRIPTION
Now ppc and aarch64 systems are properly detected and used in both the build system and the launcher, there ismore reliable detection for the makefile via a shell script (using compiler triples, which match across systems) and so on.

It's not perfect, but better what we have right now.

Also, do not set -ffast-math by default on platforms other than x86 where it's confirmed safe. On other targets it may generate unsafe code that will not behave correctly.