### PR TITLE
sound command cleanup

### DIFF
--- a/src/engine/sound.cpp
+++ b/src/engine/sound.cpp
@@ -631,11 +631,10 @@ int playsound(int n, const vec &pos, physent *d, int flags, int vol, int maxrad,
     return -1;
 }
 
-void sound(int *n, int *vol, int *flags)
+ICOMMAND(0, sound, "iib", (int *n, int *vol, int *flags),
 {
     intret(playsound(*n, camera1->o, camera1, *flags >= 0 ? *flags : SND_FORCED, *vol ? *vol : -1));
-}
-COMMAND(0, sound, "iib");
+});
 
 void removemapsounds()
 {


### PR DESCRIPTION
Some static code analysis tools get confused by ambiguous naming, this change removes an unnecessary function for the 'sound' command.