### PR TITLE
check for null pointers returned by lookupshaderbyname

### DIFF
--- a/src/engine/material.cpp
+++ b/src/engine/material.cpp
@@ -413,6 +413,7 @@ void setupmaterials(int start, int len)
     if(hasmat&(0xF<<MAT_LAVA))
     {
         useshaderbyname("lava");
+        useshaderbyname("waterfog");
         loopi(4) if(hasmat&(1<<(MAT_LAVA+i))) lookupmaterialslot(MAT_LAVA+i);
     }
     if(hasmat&(0xF<<MAT_GLASS))

--- a/src/engine/shader.cpp
+++ b/src/engine/shader.cpp
@@ -1532,6 +1532,7 @@ void setblurshader(int pass, int size, int radius, float *weights, float *offset
         defformatstring(name, "blur%c%d%s", 'x'+pass, radius, target == GL_TEXTURE_RECTANGLE ? "rect" : "");
         s = lookupshaderbyname(name);
     }
+    if(!s) return;
     s->set();
     LOCALPARAMV(weights, weights, 8);
     float scaledoffsets[8];

--- a/src/engine/texture.h
+++ b/src/engine/texture.h
@@ -458,13 +458,13 @@ struct LocalShaderParam
     do { \
         static Shader *name##shader = NULL; \
         if(!name##shader) name##shader = lookupshaderbyname(#name); \
-        name##shader->set(__VA_ARGS__); \
+        if(name##shader) name##shader->set(__VA_ARGS__); \
     } while(0)
 #define SETVARIANT(name, ...) \
     do { \
         static Shader *name##shader = NULL; \
         if(!name##shader) name##shader = lookupshaderbyname(#name); \
-        name##shader->setvariant(__VA_ARGS__); \
+        if(name##shader) name##shader->setvariant(__VA_ARGS__); \
     } while(0)
 
 struct ImageData

--- a/src/engine/water.cpp
+++ b/src/engine/water.cpp
@@ -667,14 +667,17 @@ void renderwater()
         Shader *belowshader = NULL;
         if(drawtex != DRAWTEX_MINIMAP) SETWATERSHADER(below, underwater);
 
-        aboveshader->set();
-        loopv(surfs)
+        if(aboveshader)
         {
-            materialsurface &m = surfs[i];
-            if(camera1->o.z < m.o.z - WATER_OFFSET) continue;
-            renderwater(m);
+            aboveshader->set();
+            loopv(surfs)
+            {
+                materialsurface &m = surfs[i];
+                if(camera1->o.z < m.o.z - WATER_OFFSET) continue;
+                renderwater(m);
+            }
+            xtraverts += gle::end();
         }
-        xtraverts += gle::end();
 
         if(belowshader)
         {


### PR DESCRIPTION
`lookupshaderbyname()` may return NULL if the shader failed to compile (GLSL error), or the shader just wasn't preloaded yet.

Also, it turns out the engine uses the `waterfog` shader when the camera is inside lava. However, `waterfog` is only loaded if the map has water. This PR preloads it for lava as well.

Fixes #1008.
