### PR TITLE
Fixed bug where enemies spawn instantly regardless of enemyspawntime

### DIFF
--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -897,7 +897,13 @@ namespace server
 
         bool canspawn(clientinfo *ci, bool tryspawn = false)
         {
-            if(ci->actortype >= A_ENEMY) return true;
+            if(ci->actortype >= A_ENEMY)
+            {
+              //note: if actor spawns < enemylimit, some spawns are never used
+              if(!ci->lastdeath) return true;
+              else if(gamemillis > ci->lastdeath + G(enemyspawntime)) return true;
+              else return false;
+            }
             else if(tryspawn)
             {
                 if(m_loadout(gamemode, mutators) && !chkloadweap(ci)) return false;


### PR DESCRIPTION
I could make a ticket if you want, but the fix was very simple, and confirming the fix worked was very straightforward. Let me know if I'm using the proper etiquette for contributing.
