### PR TITLE
dynamic flag for spinning mapmodels

### DIFF
--- a/src/engine/rendermodel.cpp
+++ b/src/engine/rendermodel.cpp
@@ -567,6 +567,11 @@ foundbatch:
     b->batched = idx;
 }
 
+static inline bool isbatchdynamic(modelbatch &b)
+{
+    return b.m->animated() || b.flags&MDL_FORCEDYNAMIC;
+}
+
 static inline void renderbatchedmodel(model *m, batchedmodel &b)
 {
     if(b.attached>=0) b.state.attached = &modelattached[b.attached];
@@ -670,7 +675,7 @@ int batcheddynamicmodels()
     loopv(batches)
     {
         modelbatch &b = batches[i];
-        if(!(b.flags&MDL_MAPMODEL) || !b.m->animated()) continue;
+        if(!(b.flags&MDL_MAPMODEL) || !isbatchdynamic(b)) continue;
         for(int j = b.batched; j >= 0;)
         {
             batchedmodel &bm = batchedmodels[j];
@@ -698,7 +703,7 @@ int batcheddynamicmodelbounds(int mask, vec &bbmin, vec &bbmax)
     loopv(batches)
     {
         modelbatch &b = batches[i];
-        if(!(b.flags&MDL_MAPMODEL) || !b.m->animated()) continue;
+        if(!(b.flags&MDL_MAPMODEL) || !isbatchdynamic(b)) continue;
         for(int j = b.batched; j >= 0;)
         {
             batchedmodel &bm = batchedmodels[j];
@@ -719,7 +724,7 @@ void rendershadowmodelbatches(bool dynmodel)
     loopv(batches)
     {
         modelbatch &b = batches[i];
-        if(!b.m->shadow || (!dynmodel && (!(b.flags&MDL_MAPMODEL) || b.m->animated()))) continue;
+        if(!b.m->shadow || (!dynmodel && (!(b.flags&MDL_MAPMODEL) || isbatchdynamic(b)))) continue;
         bool rendered = false;
         for(int j = b.batched; j >= 0;)
         {
@@ -741,7 +746,7 @@ void rendermapmodelbatches()
         modelbatch &b = batches[i];
         if(!(b.flags&MDL_MAPMODEL)) continue;
         b.m->startrender();
-        setaamask(b.m->animated());
+        setaamask(isbatchdynamic(b));
         for(int j = b.batched; j >= 0;)
         {
             batchedmodel &bm = batchedmodels[j];
@@ -897,7 +902,7 @@ void endmodelquery()
         int j = b.batched;
         if(j < modelquerymodels) continue;
         b.m->startrender();
-        setaamask(!(b.flags&MDL_MAPMODEL) || b.m->animated());
+        setaamask(!(b.flags&MDL_MAPMODEL) || isbatchdynamic(b));
         do
         {
             batchedmodel &bm = batchedmodels[j];

--- a/src/engine/renderva.cpp
+++ b/src/engine/renderva.cpp
@@ -576,6 +576,7 @@ void getmapmodelstate(extentity &e, entmodelstate &mdl)
     if(e.attrs[10]) mdl.yaw += e.attrs[10]*lastmillis/1000.0f;
     if(e.attrs[11]) mdl.pitch += e.attrs[11]*lastmillis/1000.0f;
     if(e.attrs[12]) mdl.roll += e.attrs[12]*lastmillis/1000.0f;
+    if(e.attrs[10] || e.attrs[11] || e.attrs[12]) mdl.flags |= MDL_FORCEDYNAMIC;
     mdl.lodoffset = e.attrs[15];
     if(e.attrs[17] > 0) mdl.speed = 1/float(e.attrs[17]/100.f);
 }

--- a/src/shared/ents.h
+++ b/src/shared/ents.h
@@ -38,7 +38,24 @@ struct entity : entbase
 };
 
 enum { MAXMDLMATERIALS = 3 };
-enum { MDL_CULL_VFC = 1<<0, MDL_CULL_DIST = 1<<1, MDL_CULL_OCCLUDED = 1<<2, MDL_CULL_QUERY = 1<<3, MDL_FULLBRIGHT = 1<<4, MDL_NORENDER = 1<<5, MDL_MAPMODEL = 1<<6, MDL_NOBATCH = 1<<7, MDL_ONLYSHADOW = 1<<8, MDL_NOSHADOW = 1<<9, MDL_FORCESHADOW = 1<<10, MDL_FORCETRANSPARENT = 1<<11, MDL_NOMIXER = 1<<12, MDL_NOPATTERN = 1<<13 };
+enum
+{
+    MDL_CULL_VFC         = 1<<0,
+    MDL_CULL_DIST        = 1<<1,
+    MDL_CULL_OCCLUDED    = 1<<2,
+    MDL_CULL_QUERY       = 1<<3,
+    MDL_FULLBRIGHT       = 1<<4,
+    MDL_NORENDER         = 1<<5,
+    MDL_MAPMODEL         = 1<<6,
+    MDL_NOBATCH          = 1<<7,
+    MDL_ONLYSHADOW       = 1<<8,
+    MDL_NOSHADOW         = 1<<9,
+    MDL_FORCESHADOW      = 1<<10,
+    MDL_FORCETRANSPARENT = 1<<11,
+    MDL_NOMIXER          = 1<<12,
+    MDL_NOPATTERN        = 1<<13,
+    MDL_FORCEDYNAMIC     = 1<<14
+};
 
 struct model;
 struct modelattach


### PR DESCRIPTION
Fixes smcache oddities and possibly improves aa masking on spinning mapmodels set by ent attrs