### PR TITLE
Far sounds

### DIFF
--- a/src/engine/sound.h
+++ b/src/engine/sound.h
@@ -34,7 +34,7 @@ struct soundsample;
 struct soundslot
 {
     vector<soundsample *> samples;
-    int vol, maxrad, minrad;
+    int vol, maxrad, minrad, variants, fardistance;
     char *name;
 
     soundslot();


### PR DESCRIPTION
By using the 7th argument of registersound you may specify the distance threshold,
above which alternative sound samples will be used. Samples used need to have the "far" suffix.
Requires an equal amount of variants as the non-far versions.
If unspecified, no far variants will be used.

For example, if we have 3 variants for sound named "foobar" and we have far threshold set,
we require the following sound files to exist:

foobar, foobar2, foobar3, foobarfar, foobarfar2, foobarfar3