### PR TITLE
allow point lights to be linked to triggers

### DIFF
--- a/src/engine/light.cpp
+++ b/src/engine/light.cpp
@@ -40,7 +40,7 @@ GETSKYPIE(lightpitch, float);
 
 bool getlightfx(const extentity &e, int *radius, int *spotlight, vec *color, bool normalize, bool dyncheck)
 {
-    if(!entities::isallowed(e)) return false;
+    if(!entities::isallowed(e) || !e.spawned()) return false;
     if(dyncheck && e.flags&EF_DYNAMIC) return false;
     if(color)
     {
@@ -641,4 +641,3 @@ void initlights()
     clearshadowcache();
     loaddeferredlightshaders();
 }
-

--- a/src/game/entities.cpp
+++ b/src/game/entities.cpp
@@ -760,7 +760,7 @@ namespace entities
     {
         switch(e.type)
         {
-            case TRIGGER: case MAPMODEL: case PARTICLES: case MAPSOUND: case LIGHTFX: case TELEPORT: case PUSHER:
+            case TRIGGER: case MAPMODEL: case PARTICLES: case MAPSOUND: case LIGHTFX: case TELEPORT: case LIGHT: case PUSHER:
                 return delay ? TRIGGERDELAY : TRIGGERTIME;
                 break;
             default: break;
@@ -1840,6 +1840,8 @@ namespace entities
                 if(e.attrs[6] < 0) e.attrs[6] = 0; // flags, clamp
                 if(e.attrs[7] < 0) e.attrs[7] = 0; // palette, clamp
                 if(e.attrs[8] < 0) e.attrs[8] = 0; // palindex, clamp
+                if(!e.spawned()) e.setspawned(1);
+                FIXEMIT;
                 break;
             }
             case MAPMODEL:
@@ -1966,7 +1968,7 @@ namespace entities
                 if(e.attrs[3] < 0) e.attrs[3] = 1; // radius, clamp
                 while(e.attrs[4] < 0) e.attrs[4] += 4; // state
                 while(e.attrs[4] >= 4) e.attrs[4] -= 4; // wrap both ways
-                if(cantrigger(n)) loopv(e.links) if(ents.inrange(e.links[i]) && (ents[e.links[i]]->type == MAPMODEL || ents[e.links[i]]->type == PARTICLES || ents[e.links[i]]->type == MAPSOUND || ents[e.links[i]]->type == LIGHTFX))
+                if(cantrigger(n)) loopv(e.links) if(ents.inrange(e.links[i]) && (ents[e.links[i]]->type == MAPMODEL || ents[e.links[i]]->type == PARTICLES || ents[e.links[i]]->type == MAPSOUND || ents[e.links[i]]->type == LIGHTFX || ents[e.links[i]]->type == LIGHT))
                 {
                     ents[e.links[i]]->lastemit = e.lastemit;
                     ents[e.links[i]]->setspawned(TRIGSTATE(e.spawned(), e.attrs[4]));
@@ -2086,8 +2088,8 @@ namespace entities
         if(e.type == TRIGGER && !cantrigger(index)) return;
         if(!local) e.lastemit = lastmillis;
         bool commit = false;
-        int fstent = min(firstent(MAPMODEL), min(firstent(LIGHTFX), min(firstent(PARTICLES), firstent(MAPSOUND)))),
-            lstent = max(lastent(MAPMODEL), max(lastent(LIGHTFX), max(lastent(PARTICLES), lastent(MAPSOUND))));
+        int fstent = min(firstent(MAPMODEL), min(firstent(LIGHTFX), min(firstent(LIGHT), min(firstent(PARTICLES), firstent(MAPSOUND))))),
+            lstent = max(lastent(MAPMODEL), max(lastent(LIGHTFX), max(lastent(LIGHT), max(lastent(PARTICLES), lastent(MAPSOUND)))));
         for(int i = fstent; i < lstent; ++i) if(ents[i]->links.find(index) >= 0)
         {
             gameentity &f = *(gameentity *)ents[i];
@@ -2103,6 +2105,13 @@ namespace entities
                     break;
                 }
                 case LIGHTFX:
+
+                case LIGHT:
+                {
+                    f.lastemit = e.lastemit;
+                    if(e.type == TRIGGER) f.setspawned(TRIGSTATE(e.spawned(), e.attrs[4]));
+                    break;
+                }
                 case PARTICLES:
                 {
                     f.lastemit = e.lastemit;

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -78,8 +78,13 @@ extern const enttypes enttype[] = {
                 "none",         { "" }
     },
     {
+<<<<<<< HEAD
         LIGHT,          1,          59,     0,      EU_NONE,    13,         7,          9,          -1,     11,      12,
             (1<<LIGHTFX), (1<<LIGHTFX), 0,
+=======
+        LIGHT,          1,          59,     0,      EU_NONE,    11,         -1,         -1,     9,      10,
+            (1<<LIGHTFX)|(1<<TRIGGER), (1<<LIGHTFX)|(1<<TRIGGER), 0,
+>>>>>>> ea40a898 (allow point lights to be linked to triggers)
             false,  false,  false,      false,      false,
                 "light",        { "radius", "red", "green", "blue", "flare", "fscale", "flags", "palette", "palindex", "modes", "muts", "variant", "fxlevel"  }
     },
@@ -172,8 +177,8 @@ extern const enttypes enttype[] = {
     },
     {
         TRIGGER,        1,          58,     16,     EU_AUTO,    8,          -1,         5,          -1,     7,      -1,
-            (1<<MAPMODEL)|(1<<MAPSOUND)|(1<<PARTICLES)|(1<<LIGHTFX),
-            (1<<MAPMODEL)|(1<<MAPSOUND)|(1<<PARTICLES)|(1<<LIGHTFX),
+            (1<<MAPMODEL)|(1<<MAPSOUND)|(1<<PARTICLES)|(1<<LIGHTFX)|(1<<LIGHT),
+            (1<<MAPMODEL)|(1<<MAPSOUND)|(1<<PARTICLES)|(1<<LIGHTFX)|(1<<LIGHT),
             (1<<ENT_PLAYER)|(1<<ENT_AI),
             false,  true,   true,       false,      true,
                 "trigger",      { "id", "type", "action", "radius", "state", "modes", "muts", "variant" }

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -78,13 +78,8 @@ extern const enttypes enttype[] = {
                 "none",         { "" }
     },
     {
-<<<<<<< HEAD
         LIGHT,          1,          59,     0,      EU_NONE,    13,         7,          9,          -1,     11,      12,
-            (1<<LIGHTFX), (1<<LIGHTFX), 0,
-=======
-        LIGHT,          1,          59,     0,      EU_NONE,    11,         -1,         -1,     9,      10,
             (1<<LIGHTFX)|(1<<TRIGGER), (1<<LIGHTFX)|(1<<TRIGGER), 0,
->>>>>>> ea40a898 (allow point lights to be linked to triggers)
             false,  false,  false,      false,      false,
                 "light",        { "radius", "red", "green", "blue", "flare", "fscale", "flags", "palette", "palindex", "modes", "muts", "variant", "fxlevel"  }
     },


### PR DESCRIPTION
Allows light entities to be directly linked to a trigger. 

There are a few use cases for this feature, one being that light sources for a sword weapon spawn (eg;volumetric light above the weapon platform) can be hidden when $mutsbitclassic isn't set. 

I'm not sure if i've missed anything, but seems to work fine from my testing locally.