### PR TITLE
dont adddynlight for player illum* whilst spectating

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1132,7 +1132,7 @@ namespace game
                 }
                 adddynlight(d->center(), d->height*intensity*pc, pulsecolour(d, PULSE_SHOCK).mul(pc), 0, 0);
             }
-            if(d->actortype < A_ENEMY && getillumlevel() > 0 && getillumradius() > 0)
+            if(d->actortype < A_ENEMY && d->state != CS_SPECTATOR && getillumlevel() > 0 && getillumradius() > 0)
                 adddynlight(d->center(), getillumradius(), vec::fromcolor(getcolour(d, playereffecttone, getillumlevel())), 0, 0);
         }
     }


### PR DESCRIPTION
Fix for illum* dynlight not being removed when spectating.

(If illumuradius/illumlevel is set, once entering spectator mode the dynlight stays at the last position whilst the player was spawned.)