### PR TITLE
add UI setting to control hud padding

### DIFF
--- a/config/ui/hud.cfg
+++ b/config/ui/hud.cfg
@@ -1421,7 +1421,7 @@ ui_hud_progress = [
 
 ui_hud_headsup = [
     if (isconnected) [
-        uispace $ui_padwin $ui_padwin [
+        uispace $ui_padhudh $ui_padhudv [
             uialign 1 -1
             uihlist 0 [
                 uialign 1 -1
@@ -1431,7 +1431,7 @@ ui_hud_headsup = [
                 ]
             ]
         ]
-        uispace $ui_padwin $ui_padwin [
+        uispace $ui_padhudh $ui_padhudv [
             uialign -1 1
             uihlist $ui_padsmall [
             uialign -1 1
@@ -1444,7 +1444,7 @@ ui_hud_headsup = [
                 ]
             ]
         ]
-        uispace $ui_padwin $ui_padwin [
+        uispace $ui_padhudh $ui_padhudv [
             uialign 0 1
             uivlist $ui_padsmall [
                 uialign 0 1
@@ -1454,7 +1454,7 @@ ui_hud_headsup = [
                 ]
             ]
         ]
-        uispace $ui_padwin $ui_padwin [
+        uispace $ui_padhudh $ui_padhudv [
             uialign 1 1
             uivlist $ui_padsmall [
                 uialign 1 1
@@ -1468,7 +1468,7 @@ ui_hud_headsup = [
             ui_hud_midradar
         ]
     ] [
-        uispace $ui_padwin $ui_padwin [
+        uispace $ui_padhudh $ui_padhudv [
             uialign 0 0
             uivlist $ui_padsmall [
                 uialign 0 0
@@ -1481,7 +1481,7 @@ ui_hud_headsup = [
             ]
         ]
     ]
-    uispace $ui_padwin $ui_padwin [
+    uispace $ui_padhudh $ui_padhudv [
         uiclamp 1 1
         uialign -1 -1
         uihlist 0 [

--- a/config/ui/settings.cfg
+++ b/config/ui/settings.cfg
@@ -81,6 +81,8 @@ ui_tip_settings_mouseinvert = [uitextleft "Toggles inversion of the mouse's y-ax
 ui_tip_settings_keybinds = [uitextleft "Customize or modify key bindings" $ui_texttip]
 //user interface
 ui_tip_settings_uiscale = [uitextleft "Scale the user interface (including the HUD) by this factor" $ui_texttip]
+ui_tip_settings_ui_padhudh = [uitextleft "Scale the horizontal border of the HUD" $ui_texttip]
+ui_tip_settings_ui_padhudv = [uitextleft "Scale the vertical border of the HUD" $ui_texttip]
 ui_tip_settings_showfps = [uitextleft "Show framerate with the following information readouts:^n0: off^n1: Average framerate^n2: Average framerate and maximum/minimum as offset^n3: Average framerate and range (Min to Max)^n4: Average framerate and average and worst frametime" $ui_texttip]
 ui_tip_settings_showstats = [uitextleft "Show information about the map's geometry counts:^n0: off^n1: Edit mode only^n2: All modes" $ui_texttip]
 ui_tip_settings_showtimestyle = [uitextleft "Format the remaining time left in the game:^n0: seconds only, to tenths place^n1: minutes and seconds, to thousandths place^n2: minutes and seconds, to tenths place ^n3: minutes and seconds, no decimal^n4: minutes and seconds, postfixed with 'm' and 's'" $ui_texttip]
@@ -1010,6 +1012,38 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                         4 "150%"   []
                                         5 "200%"   []
                                     ] [uialign 1 0] "settings_uiscale"
+                                ]
+                                uitablerow [
+                                    uihlist $ui_padbutton [
+                                        uifill $ui_checksize
+                                        uitextleft "Horizontal HUD padding"
+                                        uialign -1 0
+                                    ]
+                                    uihlist $ui_padbutton [
+                                        uihorzslider "ui_padhudh" 0.01 1.0 0.001 0.2 0.025 [
+                                            uivlist 0 [
+                                                uifill 0.050 0
+                                                uitext (format "%1%%" (toint (*f $ui_padhudh 100)))
+                                            ]
+                                        ] "settings_ui_padhudh"
+                                        uialign 1 0
+                                    ]
+                                ]
+                               uitablerow [
+                                    uihlist $ui_padbutton [
+                                        uifill $ui_checksize
+                                        uitextleft "Vertical HUD padding"
+                                        uialign -1 0
+                                    ]
+                                    uihlist $ui_padbutton [
+                                        uihorzslider "ui_padhudv" 0.01 1.0 0.001 0.2 0.025 [
+                                            uivlist 0 [
+                                                uifill 0.050 0
+                                                uitext (format "%1%%" (toint (*f $ui_padhudv 100)))
+                                            ]
+                                        ] "settings_ui_padhudv"
+                                        uialign 1 0
+                                    ]
                                 ]
                                 uitablerow [
                                     uihlist $ui_padbutton [

--- a/config/ui/style.cfg
+++ b/config/ui/style.cfg
@@ -20,6 +20,8 @@ deffvarp ui_texttipsmall $fvaridxnonzero 0.75 $fvaridxmax
 deffvarp ui_texttiptiny $fvaridxnonzero 0.65 $fvaridxmax
 
 deffvarp ui_padwin $fvaridxnonzero 0.010 $fvaridxmax
+deffvarp ui_padhudh $fvaridxnonzero 0.010 $fvaridxmax
+deffvarp ui_padhudv $fvaridxnonzero 0.010 $fvaridxmax
 deffvarp ui_padlarge $fvaridxnonzero 0.020 $fvaridxmax
 deffvarp ui_padbutton $fvaridxnonzero 0.008 $fvaridxmax
 deffvarp ui_padnormal $fvaridxnonzero 0.006 $fvaridxmax


### PR DESCRIPTION
Was suggested on discord that this could be useful for ultrawide monitors;

Changes proposed in this request:
- allows horizontal/vertical scaling of the HUD to be closer to the centre of the screen
- add sliders to User Interface settings in the menu