### PR TITLE
animmodel vertex color fixes

### DIFF
--- a/config/glsl/model.cfg
+++ b/config/glsl/model.cfg
@@ -236,6 +236,9 @@ modelvertexshader = [
             varying vec2 texcoord1;
         ])
         @(if (mdlopt "w") [windanimdefs "camprojmatrix"])
+        @(if $debugvertcolors [result [
+            varying vec4 vcolordbg;
+        ]])
 
         void main(void)
         {
@@ -248,8 +251,13 @@ modelvertexshader = [
             ]])
 
             gl_Position = modelmatrix * mpos;
-
+            @(if $debugvertcolors [result [
+                vcolordbg = vec4(0, 0, 0, 0);
+            ]])
             @(if (mdlopt "w") [windanim "camprojmatrix"])
+            @(if (&& $debugvertcolors (mdlopt "w")) [result [
+                vcolordbg = vcolor;
+            ]])
 
             texcoord0 = vtexcoord0 + texscroll;
 
@@ -312,6 +320,9 @@ modelfragmentshader = [
         @(msaainterpfrag)
         varying vec2 texcoord0;
         uniform float aamask;
+        @(if $debugvertcolors [result [
+            varying vec4 vcolordbg;
+        ]])
 
         void main(void)
         {
@@ -391,6 +402,10 @@ modelfragmentshader = [
                     #define packnorm colorscale.a
                 ])
             ]] [gglowpack "" packnorm])
+
+            @(if $debugvertcolors [result [
+                gcolor = vcolordbg;
+            ]])
 
             @(gnormpackdef normal packnorm)
 

--- a/config/stdlib.cfg
+++ b/config/stdlib.cfg
@@ -286,3 +286,5 @@ decalload = [
 autotexangle = [
     vangle (atan (divf $arg1 8))
 ]; setcomplete autotexangle 1
+
+defvar debugvertcolors 0 0 1 resetgl

--- a/src/engine/animmodel.h
+++ b/src/engine/animmodel.h
@@ -585,12 +585,13 @@ struct animmodel : model
 
     struct meshgroup
     {
+        model *m;
         meshgroup *next;
         int shared;
         char *name;
         vector<mesh *> meshes;
 
-        meshgroup() : next(NULL), shared(0), name(NULL)
+        meshgroup() : m(NULL), next(NULL), shared(0), name(NULL)
         {
         }
 
@@ -1689,7 +1690,11 @@ struct animmodel : model
         if(flipy()) translate.y = -translate.y;
 
         if(!success) return false;
-        loopv(parts) if(!parts[i]->meshes) return false;
+        loopv(parts)
+        {
+            if(!parts[i]->meshes) return false;
+            parts[i]->meshes->m = this;
+        }
 
         loaded();
         return true;

--- a/src/engine/model.h
+++ b/src/engine/model.h
@@ -29,6 +29,7 @@ struct model
     virtual bool pitched() const { return true; }
     virtual bool alphatested() const { return false; }
     virtual bool alphablended() const { return false; }
+    virtual bool needscolor() const { return wind != 0.0f; }
 
     virtual void setshader(Shader *shader) {}
     virtual void setenvmap(float envmapmin, float envmapmax, Texture *envmap) {}

--- a/src/engine/skelmodel.h
+++ b/src/engine/skelmodel.h
@@ -254,7 +254,7 @@ struct skelmodel : animmodel
             vv.pos = hvec4(v.pos, 1);
             vv.tc = v.tc;
             vv.tangent = v.tangent;
-            vv.col = vcolors ? vcolors[j] : bvec4(255, 255, 255, 255);
+            vv.col = vcolors ? vcolors[j] : bvec4(0, 0, 0, 0);
         }
 
         inline void assignvert(vvertgw &vv, int j, vert &v, blendcombo &c)
@@ -271,7 +271,7 @@ struct skelmodel : animmodel
             vv.tc = v.tc;
             vv.tangent = v.tangent;
             c.serialize(vv);
-            vv.col = vcolors ? vcolors[j] : bvec4(255, 255, 255, 255);
+            vv.col = vcolors ? vcolors[j] : bvec4(0, 0, 0, 0);
         }
 
         template<class T>
@@ -1231,7 +1231,8 @@ struct skelmodel : animmodel
                     loopv(blendcombos) blendcombos[i].interpindex = -1;
                 }
 
-                looprendermeshes(skelmesh, m, { if(m.vcolors) { usecolor = true; break; }});
+                if(m && m->needscolor()) usecolor = true;
+                else looprendermeshes(skelmesh, m, { if(m.vcolors) { usecolor = true; break; }});
                 gle::bindvbo(vc.vbuf);
                 #define GENVBO(type, args) \
                     do \

--- a/src/engine/vertmodel.h
+++ b/src/engine/vertmodel.h
@@ -98,7 +98,7 @@ struct vertmodel : animmodel
             vv.pos = hvec4(v.pos, 1);
             vv.tc = tc.tc;
             vv.tangent = v.tangent;
-            vv.col = vcolors ? vcolors[j] : bvec4(255, 255, 255, 255);
+            vv.col = vcolors ? vcolors[j] : bvec4(0, 0, 0, 0);
         }
 
         template<class T>
@@ -309,7 +309,8 @@ struct vertmodel : animmodel
             }
             else
             {
-                looprendermeshes(vertmesh, m, { if(m.vcolors) { usecolor = true; break; }});
+                if(m && m->needscolor()) usecolor = true;
+                else looprendermeshes(vertmesh, m, { if(m.vcolors) { usecolor = true; break; }});
                 gle::bindvbo(vc.vbuf);
                 #define GENVBO(type) \
                     do \


### PR DESCRIPTION
This change makes sure the vertex colors are always bound when a model needs them (e.g. has wind enabled).

Also, introduced 'debugvertcolors 0/1' to view vertex colors on wind animated models in-game.