### PR TITLE
Request dedicated GPU when starting Red Eclipse from the `.desktop` file

### DIFF
--- a/src/install/nix/redeclipse.desktop.am
+++ b/src/install/nix/redeclipse.desktop.am
@@ -19,5 +19,6 @@ Comment[sv]=Förstapersonsskjutare med rörlig spelstil och inbyggd baneditor
 Comment[fr]=Jeu de tir à la première personne avec un éditeur de cartes intégré
 Icon=@APPNAME@
 Exec=@APPNAME@
+PrefersNonDefaultGPU=true
 Categories=Game;ActionGame;
 Keywords=fps;action;multiplayer;play;arena;mapeditor;


### PR DESCRIPTION
See <https://www.hadess.net/2020/05/dual-gpu-support-launch-on-discrete-gpu.html> for more information about this newly added `.desktop` entry property.