### PR TITLE
add clearconsole & clearchat commands

### DIFF
--- a/config/usage.cfg
+++ b/config/usage.cfg
@@ -497,6 +497,8 @@ setdesc "showfps" "display the frames per second counter on the hud;^n0 = no dis
 setdesc "showloadinglogos" "display logos while not in game" "boolean"
 setdesc "showvelocity" "display the velocity indicator on the hud" "value"
 setdesc "showconsole" "display the console" "boolean"
+setdesc "clearconsole" "clears the selected console output;^n-1: all^n0: debug^n1: event^n2: frag^n3: chat" "console-index"
+setdesc "clearchat" "clears the chat console output"
 setdesc "showminimap" "toggle minimap visibility" "boolean"
 setdesc "showhud" "toggle heads up display visibility" "boolean"
 setdesc "showmovecount" "toggle remaining impulse moves meter" "boolean"

--- a/src/engine/console.cpp
+++ b/src/engine/console.cpp
@@ -713,10 +713,18 @@ void processkey(int code, bool isdown)
     else if(!consolekey(code, isdown) && !hud::keypress(code, isdown) && haskey) execbind(*haskey, isdown);
 }
 
-void clear_console()
+void clear_binds()
 {
     keyms.clear();
 }
+
+void clear_console(int type)
+{
+   if (type >= 0) conlines[type].clear();
+   else loopi(CON_MAX-1) conlines[i].clear();
+}
+ICOMMAND(0, clearconsole, "i", (int *type), clear_console(clamp(*type, -1, CON_MAX-1)));
+ICOMMAND(0, clearchat, "", (), clear_console(CON_MESG));
 
 void writebinds(stream *f)
 {

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -96,7 +96,7 @@ void cleanup()
     UI::cleanup();
     cleanupwind();
     extern void clear_command(); clear_command();
-    extern void clear_console(); clear_console();
+    extern void clear_binds(); clear_binds();
     extern void clear_models();  clear_models();
 
     stopsound();


### PR DESCRIPTION
Changes proposed in this request:

- add `/clearconsole <console id>` command
- add `/clearchat` command
- add command usage to usage.cfg
- renamed the previous `clear_console()` to `clear_binds()` as it was only doing `keyms.clear();`