### PR TITLE
Display IDF_CLIENT variables as "Game" in the console usage display.

### DIFF
--- a/config/ui/console.cfg
+++ b/config/ui/console.cfg
@@ -130,7 +130,9 @@ ui_console_usage_text = [
     idtype_s = ""
     // IDF_CLIENT || IDF_SERVER
     if (|| (& $idflags $idfbitclient) (& $idflags $idfbitserver)) [
-        idtype_s = (concatif $idtype_s (? (& $idflags $idfbitclient) "Client" "Server"))
+        // Describe IDF_CLIENT var as "Game" to clarify that changing it will affect the entire game, not just the user's client.
+        // IDF_SERVER can be obviously described as "Server"
+        idtype_s = (concatif $idtype_s (? (& $idflags $idfbitclient) "Game" "Server"))
     ]
     // not ID_COMMAND
     if (!= $idtype $ididxcommand) [


### PR DESCRIPTION
This PR changes it from "Client", which is somewhat misleading, as changing the variable does not affect only your client, but the whole game.
"Game" was also the description in 1.x versions.
