### PR TITLE
Put back fx emitters that failed to instantiate

### DIFF
--- a/src/engine/fx.h
+++ b/src/engine/fx.h
@@ -256,7 +256,7 @@ namespace fx
         void unhook();
         void updateend(int end);
         void init(emitter **newhook);
-        void instantiate(int index, instance *parent = NULL);
+        bool instantiate(int index, instance *parent = NULL);
         void prolong();
         bool done();
         void update();

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1417,7 +1417,7 @@ namespace game
                     safefindorientation(d->o, d->yaw, d->pitch, targ);
                     targ.sub(from).normalize().add(from);
                     fx::createfx(fxindex, from, targ, 1.0f, 1.0f, bvec(color), d, &d->weaponfx);
-                    d->weaponfx->setparam(W_FX_POWER_PARAM, amt);
+                    if(d->weaponfx) d->weaponfx->setparam(W_FX_POWER_PARAM, amt);
                 }
             }
         }

--- a/src/game/projs.cpp
+++ b/src/game/projs.cpp
@@ -139,12 +139,12 @@ namespace projs
         {
             case PRJ_FX_LIFE:
                 param = clamp(proj.lifespan, 0.0f, 1.0f);
-                e->setparam(P_FX_LIFETIME_PARAM, param);
+                if(e) e->setparam(P_FX_LIFETIME_PARAM, param);
                 break;
 
             case PRJ_FX_BOUNCE:
                 param = clamp(proj.vel.magnitude()*proj.curscale*0.005f, 0.0f, 1.0f);
-                e->setparam(P_FX_BOUNCE_VEL_PARAM, param);
+                if(e) e->setparam(P_FX_BOUNCE_VEL_PARAM, param);
                 break;
         }
     }
@@ -1281,7 +1281,7 @@ namespace projs
                 safefindorientation(d->o, d->yaw, d->pitch, targ);
                 targ.sub(from).normalize().add(from);
                 fx::createfx(fxindex, from, targ, 1.0f, fxscale, bvec(color), d, &d->weaponfx);
-                d->weaponfx->setparam(W_FX_POWER_PARAM, scale);
+                if(d->weaponfx) d->weaponfx->setparam(W_FX_POWER_PARAM, scale);
             }
         }
         loopv(shots)


### PR DESCRIPTION
Fixes the case when FX emitters would be created without any FX instances, due to shortage.