### PR TITLE
sort texture slot numbers when variant option is enabled

### DIFF
--- a/config/ui/editing.cfg
+++ b/config/ui/editing.cfg
@@ -214,24 +214,12 @@ uimenu "textures" "Texture Browser" $texturetex [
                     uigrid 8 0.0078125 0.0078125 [
                         uialign -1 -1
                         uihover [] [ui_tex_current_slot = (getseltex)]
-                        if (= $ui_tex_show_all 1) [
-                            looptexmru (texmru) 0 tex [
-                                if (|| (=s $ui_tex_search_criteria "") (!= (strstr (gettexname $tex) $ui_tex_search_criteria) -1)) [
-                                    uivslotview $tex $ui_buttonzs $ui_buttonzs [
-                                        if (= $tex (getseltex)) [uioutline 0xFF0000; uiclamp- 1 1 1 1] // Outline currently selected texture
-                                        uihold [uioutline 0xC0C0C0; uiclamp- 1 1 1 1] [uihover [uioutline 0xFFFFFF; uiclamp- 1 1 1 1; ui_tex_current_slot = $tex]]
-                                        uirelease [uiclose "textures"; settex $tex] //this is the part that selects the texture at the cursor
-                                    ]
-                                ]
-                            ]
-                        ] [
-                            loop slot (numslots) [
-                                if (|| (=s $ui_tex_search_criteria "") (!= (strstr (gettexname $slot) $ui_tex_search_criteria) -1)) [
-                                    uislotview $slot $ui_buttonzs $ui_buttonzs [
-                                        if (= $slot (getseltex)) [uioutline 0xFF0000; uiclamp- 1 1 1 1] // Outline currently selected texture
-                                        uihold [uioutline 0xC0C0C0; uiclamp- 1 1 1 1] [uihover [uioutline 0xFFFFFF; uiclamp- 1 1 1 1; ui_tex_current_slot = $slot]]
-                                        uirelease [uiclose "textures"; settex (getslottex $slot)] //this is the part that selects the texture at the cursor
-                                    ]
+                        loop slot ((? (= $ui_tex_show_all 0) numslots numvslots)) [
+                            if (|| (=s $ui_tex_search_criteria "") (!= (strstr (gettexname $slot) $ui_tex_search_criteria) -1)) [
+                                (? (= $ui_tex_show_all 0) uislotview uivslotview) $slot $ui_buttonzs $ui_buttonzs [
+                                    if (= $slot (getseltex)) [uioutline 0xFF0000; uiclamp- 1 1 1 1] // Outline currently selected texture
+                                    uihold [uioutline 0xC0C0C0; uiclamp- 1 1 1 1] [uihover [uioutline 0xFFFFFF; uiclamp- 1 1 1 1; ui_tex_current_slot = $slot]]
+                                    uirelease [uiclose "textures"; settex $slot] //this is the part that selects the texture at the cursor
                                 ]
                             ]
                         ]


### PR DESCRIPTION
Fixes unordered texture slots in the texture browser, making it easier to find texture previews by slot #.

Changes proposed in this request:

The current `looptexmru (texmru) 0 tex [ ... ]` loop seems to return a chaotic unordered list of textures, so 
- loop over numslots/numvslots instead of texmru when "show variants" is enabled
- combine into one loop
