### PR TITLE
fix #315 - add custom colours to routes

### DIFF
--- a/config/usage.cfg
+++ b/config/usage.cfg
@@ -759,6 +759,8 @@ setdesc "sendmap" "manually sends map to the server"
 setdesc "getmap" "manually retrieves map from the server"
 setdesc "newmap" "create new map with the specified gridpower and name" "size" "name"
 setdesc "decalreset" "deletes all decal indices from map config file (including ones in use)"
+setdesc "routenames" "sets the routenames for race mode (list of names)" "text"
+setdesc "routecolours" "sets the routecolours for race mode (list of hexcolours)" "text"
 
 listcomplete "newent" "actor affinity checkpoint decal envmap light lightfx mapmodel particles playerstart pusher route sound teleport trigger weapon wind unused"
 listcomplete "entfind" "actor affinity checkpoint decal envmap light lightfx mapmodel particles playerstart pusher route sound teleport trigger weapon wind unused"

--- a/src/game/entities.cpp
+++ b/src/game/entities.cpp
@@ -41,12 +41,12 @@ namespace entities
 
     VARF(0, routeid, -1, -1, VAR_MAX, lastroutenode = -1; lastroutetime = 0; airnodes.setsize(0)); // selected route in race
     VARF(0, droproute, 0, 0, 1, lastroutenode = -1; lastroutetime = 0; airnodes.setsize(0); if(routeid < 0) routeid = 0);
-    VAR(IDF_HEX, routecolour, 0, 0xFF22FF, 0xFFFFFF);
     VAR(0, droproutedist, 1, 16, VAR_MAX);
     VAR(0, routemaxdist, 0, 64, VAR_MAX);
     VAR(IDF_PERSIST, showroutenames, 0, 1, 1);
     FVAR(IDF_PERSIST, routenameblend, 0, 1, 1);
-    SVARF(IDF_WORLD, routenames, "Easy Medium Hard", { string s; if(filterstring(s, routenames)) setsvar("routenames", s, false); });
+    SVARF(IDF_WORLD, routenames, "Easy Medium Hard", { string s; if(filterstring(s, routenames)) { delete[] routenames; routenames = newstring(s); } });
+    SVARF(IDF_WORLD, routecolours, "0x00FF00 0xFF7700 0xFF0000", { string s; if(filterstring(s, routecolours)) { delete[] routecolours; routecolours = newstring(s); } });
 
     struct rail
     {
@@ -3006,7 +3006,17 @@ namespace entities
             {
                 if(e.attrs[0] != routeid || (!m_edit(game::gamemode) && !m_race(game::gamemode))) break;
                 loopv(e.links) if(ents.inrange(e.links[i]) && ents[e.links[i]]->type == ROUTE && (!routemaxdist || o.dist(ents[e.links[i]]->o) <= routemaxdist))
-                    part_flare(o, ents[e.links[i]]->o, 1, PART_LIGHTNING_FLARE, routecolour);
+                {
+                    char *colour = indexlist(routecolours, routeid);
+                    if(colour)
+                    {
+                        if(*colour)
+                        {
+                            part_flare(o, ents[e.links[i]]->o, 1, PART_LIGHTNING_FLARE, parseint(colour));
+                        }
+                        delete[] colour;
+                    }
+                }
 
                 if(showroutenames && getfirstroute() == idx)
                 {

--- a/src/game/entities.cpp
+++ b/src/game/entities.cpp
@@ -3007,15 +3007,14 @@ namespace entities
                 if(e.attrs[0] != routeid || (!m_edit(game::gamemode) && !m_race(game::gamemode))) break;
                 loopv(e.links) if(ents.inrange(e.links[i]) && ents[e.links[i]]->type == ROUTE && (!routemaxdist || o.dist(ents[e.links[i]]->o) <= routemaxdist))
                 {
-                    char *colour = indexlist(routecolours, routeid);
-                    if(colour)
+                    int col = 0xFF22FF;
+                    char *rcol = indexlist(routecolours, routeid);
+                    if(rcol)
                     {
-                        if(*colour)
-                        {
-                            part_flare(o, ents[e.links[i]]->o, 1, PART_LIGHTNING_FLARE, parseint(colour));
-                        }
-                        delete[] colour;
+                        if(*rcol) col = parseint(rcol);
+                        delete[] rcol;
                     }
+                    part_flare(o, ents[e.links[i]]->o, 1, PART_LIGHTNING_FLARE, col);
                 }
 
                 if(showroutenames && getfirstroute() == idx)


### PR DESCRIPTION
Fixes #315 

Changes proposed in this request:
- use string value for list of `routecolours` (same method as `routenames`) so that index matches `routeid`
- add usage for `routenames` and `routecolours`

Default colours are "0x00FF00 0xFF7700 0xFF0000"  (green, orange red), but can be altered on a per map basis this way.

![2020-10-24-034338_1920x1080_scrot](https://user-images.githubusercontent.com/1535179/97066213-8763fd00-15ab-11eb-93e5-3ba04f34ad58.jpg)
![2020-10-24-034344_1920x1080_scrot](https://user-images.githubusercontent.com/1535179/97066214-87fc9380-15ab-11eb-9c3a-d4aef2a83356.jpg)
![2020-10-24-034349_1920x1080_scrot](https://user-images.githubusercontent.com/1535179/97066216-89c65700-15ab-11eb-9d8f-8aa6ede05344.jpg)
