### PR TITLE
add playershadow client var

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -390,6 +390,8 @@ namespace game
     VAR(IDF_PERSIST, playerhalotone, -1, CTONE_TEAM, CTONE_MAX-1);
     VAR(IDF_PERSIST, playerteamtone, -1, CTONE_TEAM, CTONE_MAX-1);
 
+    VAR(IDF_PERSIST, playershadow, 0, 2, 2);
+
     FVAR(IDF_PERSIST, playerovertonelevel, 0.f, 1.f, 10.f);
     FVAR(IDF_PERSIST, playerundertonelevel, 0.f, 1.f, 10.f);
     FVAR(IDF_PERSIST, playerdisplaytonelevel, 0.f, 1.f, 10.f);
@@ -3896,6 +3898,7 @@ namespace game
                 if(d->actortype >= A_ENEMY) mdl.flags |= MDL_CULL_DIST;
             }
             if(d != focus || (d != player1 ? fullbrightfocus&1 : fullbrightfocus&2)) mdl.flags |= MDL_FULLBRIGHT;
+            if((d != focus && playershadow < 2) || playershadow < 1) mdl.flags |= MDL_NOSHADOW;
         }
         else if(drawtex == DRAWTEX_HALO && (d == focus ? inzoom() : !haloallow(d))) mdl.flags |= MDL_NORENDER;
 


### PR DESCRIPTION
Changes proposed in this request:
- add `playershadow` client var

0 = no playershadows
1 = only your player shadow
2 = all player shadows

(default = 2)

Forgot to open this last week, @SniperGoth requested this previously, and seems helpful for lower end systems to optionally boost fps where some maps may be more consuming. There was discussion about making this a bitwise variable, but not sure if it's necessary for the "only enemy shadows" etc, as removing 1 shadow from a single player probably doesn't add much benefit.