### PR TITLE
skybox & cloudbox spin/yaw/roll/pitch

### DIFF
--- a/src/engine/rendersky.cpp
+++ b/src/engine/rendersky.cpp
@@ -51,14 +51,20 @@ Texture *loadskyoverlay(const char *basename)
     FVAR(IDF_WORLD, skyoverbrightmin##name, 0, 1, 16); \
     FVAR(IDF_WORLD, skyoverbrightthreshold##name, 0, 0.7f, 1); \
     FVAR(IDF_WORLD, spinsky##name, -720, 0, 720); \
-    FVAR(IDF_WORLD, rollsky##name, -720, 0, 720); \
+    FVAR(IDF_WORLD, spinskypitch##name, -720, 0, 720); \
+    FVAR(IDF_WORLD, spinskyroll##name, -720, 0, 720); \
     VAR(IDF_WORLD, yawsky##name, 0, 0, 360); \
+    VAR(IDF_WORLD, pitchsky##name, 0, 0, 360); \
+    VAR(IDF_WORLD, rollsky##name, 0, 0, 360); \
     SVARF(IDF_WORLD, cloudbox##name, "", { if(cloudbox##name[0] && checkmapvariant(type)) loadsky(cloudbox##name, clouds); }); \
     CVAR(IDF_WORLD, cloudcolour##name, 0xFFFFFF); \
     FVAR(IDF_WORLD, cloudblend##name, 0, 1.0f, 1); \
     FVAR(IDF_WORLD, spinclouds##name, -720, 0, 720); \
-    FVAR(IDF_WORLD, rollclouds##name, -720, 0, 720); \
+    FVAR(IDF_WORLD, spincloudspitch##name, -720, 0, 720); \
+    FVAR(IDF_WORLD, spincloudsroll##name, -720, 0, 720); \
     VAR(IDF_WORLD, yawclouds##name, 0, 0, 360); \
+    VAR(IDF_WORLD, pitchclouds##name, 0, 0, 360); \
+    VAR(IDF_WORLD, rollclouds##name, 0, 0, 360); \
     FVAR(IDF_WORLD, cloudclip##name, 0, 0.5f, 1); \
     SVARF(IDF_WORLD, cloudlayer##name, "", { if(cloudlayer##name[0] && checkmapvariant(type)) cloudoverlay = loadskyoverlay(cloudlayer##name); }); \
     CVAR(IDF_WORLD, cloudlayercolour##name, 0xFFFFFF); \
@@ -135,14 +141,20 @@ GETMPV(skyoverbright, float);
 GETMPV(skyoverbrightmin, float);
 GETMPV(skyoverbrightthreshold, float);
 GETMPV(spinsky, float);
-GETMPV(rollsky, float);
+GETMPV(spinskypitch, float);
+GETMPV(spinskyroll, float);
 GETMPV(yawsky, int);
+GETMPV(pitchsky, int);
+GETMPV(rollsky, int);
 GETMPV(cloudbox, const char *);
 GETMPV(cloudcolour, bvec &);
 GETMPV(cloudblend, float);
 GETMPV(spinclouds, float);
-GETMPV(rollclouds, float);
+GETMPV(spincloudspitch, float);
+GETMPV(spincloudsroll, float);
 GETMPV(yawclouds, int);
+GETMPV(pitchclouds, int);
+GETMPV(rollclouds, int);
 GETMPV(cloudclip, float);
 GETMPV(cloudlayer, const char *);
 GETMPV(cloudlayercolour, bvec &);
@@ -689,7 +701,8 @@ void drawskybox(bool clear)
         matrix4 skymatrix = cammatrix, skyprojmatrix;
         skymatrix.settranslation(0, 0, 0);
         skymatrix.rotate_around_z((getspinsky()*lastmillis/1000.0f+getyawsky())*-RAD);
-        skymatrix.rotate_around_x((getrollsky()*lastmillis/1000.0f*-RAD));
+        skymatrix.rotate_around_y((getspinskypitch()*lastmillis/1000.0f+getpitchsky())*-RAD);
+        skymatrix.rotate_around_x((getspinskyroll()*lastmillis/1000.0f+getrollsky())*-RAD);
         skyprojmatrix.mul(projmatrix, skymatrix);
         LOCALPARAM(skymatrix, skyprojmatrix);
 
@@ -715,7 +728,8 @@ void drawskybox(bool clear)
         matrix4 skymatrix = cammatrix, skyprojmatrix;
         skymatrix.settranslation(0, 0, 0);
         skymatrix.rotate_around_z((getspinclouds()*lastmillis/1000.0f+getyawclouds())*-RAD);
-        skymatrix.rotate_around_x((getrollclouds()*lastmillis/1000.0f*-RAD));
+        skymatrix.rotate_around_y((getspincloudspitch()*lastmillis/1000.0f+getpitchclouds())*-RAD);
+        skymatrix.rotate_around_x((getspincloudsroll()*lastmillis/1000.0f+getrollclouds())*-RAD);
         skyprojmatrix.mul(projmatrix, skymatrix);
         LOCALPARAM(skymatrix, skyprojmatrix);
 

--- a/src/engine/worldio.cpp
+++ b/src/engine/worldio.cpp
@@ -938,7 +938,8 @@ static void sanevars()
 
 const char *variantvars[] = {
     "ambient", "ambientscale", "skylight", "skylightscale", "fog", "fogcolour", "skybgcolour", "skybox", "skycolour", "skyblend", "skyoverbright", "skyoverbrightmin",
-    "skyoverbrightthreshold", "spinsky", "rollsky", "yawsky", "cloudbox", "cloudcolour", "cloudblend", "spinclouds", "rollclouds", "yawclouds", "cloudclip", "cloudlayer", "cloudlayercolour",
+    "skyoverbrightthreshold", "spinsky", "spinskypitch", "spinskyroll", "yawsky", "pitchsky", "rollsky", "cloudbox", "cloudcolour", "cloudblend", 
+    "spinclouds", "spincloudspitch", "spincloudsroll", "yawclouds", "pitchclouds", "rollclouds", "cloudclip", "cloudlayer", "cloudlayercolour",
     "cloudlayerblend", "cloudoffsetx", "cloudoffsety", "cloudscrollx", "cloudscrolly", "cloudscale", "spincloudlayer", "yawcloudlayer", "cloudheight", "cloudfade",
     "cloudsubdiv", "envlayer", "envlayercolour", "envlayerblend", "envoffsetx", "envoffsety", "envscrollx", "envscrolly", "envscale", "spinenvlayer", "yawenvlayer",
     "envheight", "envfade", "envsubdiv", "atmo", "atmoplanetsize", "atmoheight", "atmobright", "atmolight", "atmolightscale", "atmodisksize", "atmodiskbright",


### PR DESCRIPTION


Changes proposed in this request:
- rollsky didn't make much sense as for naming, so changed that to `spinskyroll`
- also added:
```
"spinsky", "spinskypitch", "spinskyroll",          <-- rotate around axis
"yawsky", "pitchsky", "rollsky",                   <-- constant offset
"spinclouds", "spincloudspitch", "spincloudsroll", <-- rotate around axis
"yawclouds", "pitchclouds", "rollclouds",          <-- constant offset
```
