### PR TITLE
fix grass graphics settings

### DIFF
--- a/config/ui/settings.cfg
+++ b/config/ui/settings.cfg
@@ -135,6 +135,7 @@ gfxlevels = [
         particlewind 0
         stainfade 15000
         maxstaintris 4096
+        grass 1
         grassdist 256
         smalpha 0
     ] ( = $gfxlevel 3) [//medium
@@ -154,6 +155,7 @@ gfxlevels = [
         particlewind 1
         stainfade 15000
         maxstaintris 4096
+        grass 1
         grassdist 512
         smalpha 1
     ] ( = $gfxlevel 4) [//high
@@ -173,6 +175,7 @@ gfxlevels = [
         particlewind 1
         stainfade 30000
         maxstaintris 8192
+        grass 1
         grassdist 1024
         smalpha 2
     ] ( = $gfxlevel 5) [//very high
@@ -192,6 +195,7 @@ gfxlevels = [
         particlewind 1
         stainfade 60000
         maxstaintris 8192
+        grass 1
         grassdist 1024
         smalpha 2
     ] ( = $gfxlevel 6) [//ultra
@@ -211,6 +215,7 @@ gfxlevels = [
         particlewind 1
         stainfade 60000
         maxstaintris 8192
+        grass 1
         grassdist 1024
         smalpha 2
     ]


### PR DESCRIPTION
Grass re-enabeling after set graphics settings to very low.
This fix is necessary because grass 0 is not reset to grass 1 after switching back from very low to low or higher.