### PR TITLE
Add FX light flags properties and disable shadows for flame FX

### DIFF
--- a/config/fx/lib.cfg
+++ b/config/fx/lib.cfg
@@ -1,5 +1,6 @@
 exec "config/fx/std.cfg"
 exec "config/fx/particle.cfg"
+exec "config/fx/light.cfg"
 exec "config/fx/stain.cfg"
 exec "config/fx/sound.cfg"
 exec "config/fx/wind.cfg"

--- a/config/fx/light.cfg
+++ b/config/fx/light.cfg
@@ -1,0 +1,5 @@
+L_NOSHADOW    = 1
+L_NODYNSHADOW = (<< 1 1)
+L_VOLUMETRIC  = (<< 1 2)
+L_NOSPEC      = (<< 1 3)
+L_SMALPHA     = (<< 1 4)

--- a/config/fx/projs/flame.cfg
+++ b/config/fx/projs/flame.cfg
@@ -2,7 +2,7 @@ registerfx FX_P_FLAME_LIFE $FX_TYPE_PARTICLE [
     fxpropi parttype $FX_PARTTYPE_SPLASH
     fxpropi part $PART_FLAME
     fxpropi num 1
-    fxpropf partsize 0.5
+    fxpropf partsize 0.2
     fxpropf partsize 24 $FX_MOD_LERP [
         fxpropi lerptime 500
         fxpropi lerpsquare 1
@@ -18,22 +18,45 @@ registerfx FX_P_FLAME_LIFE $FX_TYPE_PARTICLE [
     fxpropf blend 0.1
 ]
 
+registerfx FX_P_FLAME_LIFE_INIT_GLOW $FX_TYPE_PARTICLE [
+    fxparent FX_P_FLAME_LIFE
+    fxpropi emitlen 100
+    fxpropi parttype $FX_PARTTYPE_FLARE
+    fxpropi part $PART_MUZZLE_FLARE
+    fxpropc colour 0 0 255
+    fxpropf partsize 0.1
+    fxpropf partsize 2 $FX_MOD_LERP [
+        fxpropi lerptime 100
+    ]
+    fxpropf blend 0.3
+    fxpropf blend 0 $FX_MOD_LERP [
+        fxpropi lerptime 100
+    ]
+]
+
 registerfx FX_P_FLAME_LIFE_GLOW $FX_TYPE_PARTICLE [
     fxparent FX_P_FLAME_LIFE
     fxpropi parttype $FX_PARTTYPE_SINGLE
-    fxpropi part $PART_HINT_SOFT
+    fxpropi part $PART_HINT
     fxpropf partsize 0.5
     fxpropf partsize 48 $FX_MOD_LERP [
         fxpropi lerptime 500
         fxpropi lerpsquare 1
     ]
-    fxpropf partsize 4 $FX_MOD_RAND
-    fxpropc colour 255 146 82
+    fxpropc colour 0 0 255
+    fxpropc colour 255 146 82 $FX_MOD_LERP [
+        fxpropi lerptime 200
+    ]
     fxpropf blend 0.1
+    fxpropf blend 0.2 $FX_MOD_LERP [
+        fxpropi lerptime 500
+        fxpropi lerpsquare 1
+    ]
 ]
 
 registerfx FX_P_FLAME_LIFE_LIGHT $FX_TYPE_LIGHT [
     fxparent FX_P_FLAME_LIFE
+    fxpropi flags $L_NOSHADOW
     fxpropf radius 1
     fxpropf radius 128 $FX_MOD_LERP [
         fxpropi lerptime 500
@@ -42,29 +65,7 @@ registerfx FX_P_FLAME_LIFE_LIGHT $FX_TYPE_LIGHT [
     fxpropf radius 16 $FX_MOD_RAND
     fxpropf blend 0.75
     fxpropf blend 0.25 $FX_MOD_RAND
-    fxpropc colour 0 0 255
-    fxpropc colour 255 146 82 $FX_MOD_LERP [
-        fxpropi lerptime 200
-    ]
-]
-
-registerfx FX_P_FLAME_LIFE_SMOKE $FX_TYPE_PARTICLE [
-    fxparent FX_P_FLAME_LIFE
-    fxpropi parttype $FX_PARTTYPE_SPLASH
-    fxpropi part $PART_SMOKE_SOFT
-    fxpropi num 1
-    fxpropf partsize 4
-    fxpropf partsize 32 $FX_MOD_LERP [
-        fxpropi lerptime 500
-    ]
-    fxpropf vel 5
-    fxpropf shapesize 1
-    fxpropi fade 250
-    fxpropf gravity -10
-    fxpropf blend 0
-    fxpropf blend 0.1 $FX_MOD_LERP [
-        fxpropi lerptime 500
-    ]
+    fxpropc colour 255 146 82
 ]
 
 registerfx FX_P_FLAME_DESTROY $FX_TYPE_STAIN [

--- a/config/fx/weapons/flame.cfg
+++ b/config/fx/weapons/flame.cfg
@@ -2,7 +2,6 @@ registerfx FX_W_FLAME $FX_TYPE_PARTICLE [
     fxpropi emitlen 1
     fxpropi parttype $FX_PARTTYPE_SINGLE
     fxpropi part $PART_HINT
-    fxpropc colour 255 146 82
     fxpropi fade 64
     fxpropf partsize 0.2
     fxpropf partsize 0.5 $FX_MOD_RAND
@@ -17,7 +16,7 @@ registerfx FX_W_FLAME_TRAIL $FX_TYPE_PARTICLE [
     fxpropi part $PART_HINT
     fxpropc colour 100 100 255
     fxpropi num 1
-    fxpropf partsize 0.5
+    fxpropf partsize 0.25
     fxpropf vel 0
     fxpropf shapesize 1
     fxpropf blend 0.2
@@ -30,7 +29,7 @@ registerfx FX_W_FLAME_TRAIL $FX_TYPE_PARTICLE [
 
 registerfx FX_W_FLAME_SMOKE $FX_TYPE_PARTICLE [
     fxparent FX_W_FLAME
-    fx_muzzle_smoke 1500 1
+    fx_muzzle_smoke 1000 1
 ]
 
 registerfx FX_W_FLAME_FLAME_END $FX_TYPE_PARTICLE [
@@ -42,8 +41,8 @@ registerfx FX_W_FLAME_FLAME_END $FX_TYPE_PARTICLE [
     fxpropi part $PART_HINT
     fxpropc colour 255 146 82
     fxpropi num 1
-    fxpropf partsize 0.4
-    fxpropf partsize 0.2 $FX_MOD_LERP [
+    fxpropf partsize 0.2
+    fxpropf partsize 0.1 $FX_MOD_LERP [
         fxpropi lerptime 1000
     ]
     fxpropf vel 0

--- a/src/engine/fx.h
+++ b/src/engine/fx.h
@@ -76,6 +76,7 @@ namespace fx
     {
         FX_LIGHT_RADIUS = 0,
         FX_LIGHT_COLOR,
+        FX_LIGHT_FLAGS,
 
         FX_LIGHT_PROPS
     };

--- a/src/engine/fxemit.cpp
+++ b/src/engine/fxemit.cpp
@@ -296,8 +296,9 @@ namespace fx
 
         float radius = inst.getextprop<float>(FX_LIGHT_RADIUS) * scale;
         vec color = getcolor(inst, FX_LIGHT_COLOR).mul(getblend(inst)).tocolor();
+        int flags = inst.getextprop<int>(FX_LIGHT_FLAGS);
 
-        adddynlight(from, radius, vec(color));
+        adddynlight(from, radius, vec(color), 0, 0, flags);
     }
 
     static void soundfx(instance &inst)

--- a/src/engine/fxprop.h
+++ b/src/engine/fxprop.h
@@ -263,6 +263,12 @@ namespace fx
             PROP_COLOR,
             bvec(0, 0, 0), bvec(255, 255, 255), bvec(255, 255, 255),
             BIT(FX_MOD_RAND) | BIT(FX_MOD_LERP)
+        ),
+        fxpropertydef(
+            "flags",
+            PROP_INT,
+            0, 0, INT_MAX,
+            0
         )
     };
 


### PR DESCRIPTION
* Adds the ability to set flags on light FX.
* Disables shadows for flame projectiles to buy performance on slower machines.
* Visually tweaks the flame projectile effect.