### PR TITLE
add texture tag descriptions

### DIFF
--- a/src/engine/octaedit.cpp
+++ b/src/engine/octaedit.cpp
@@ -3084,6 +3084,13 @@ void getslottex(int *idx)
     intret(slot.variants->index);
 }
 
+void gettextags(int *idx)
+{
+    if(*idx < 0 || !slots.inrange(*idx)) { intret(-1); return; }
+    Slot &slot = lookupslot(*idx, false);
+    result(slot.tags);
+}
+
 COMMANDN(0, edittex, edittex_, "i");
 ICOMMAND(0, settex, "i", (int *tex), { if(!vslots.inrange(*tex) || noedit()) return; filltexlist(); edittex(*tex); });
 COMMAND(0, gettex, "");
@@ -3099,6 +3106,7 @@ ICOMMAND(0, numslots, "", (), intret(slots.length()));
 ICOMMAND(0, numdecalslots, "", (), intret(decalslots.length()));
 COMMAND(0, getslottex, "i");
 ICOMMAND(0, texloaded, "i", (int *tex), intret(slots.inrange(*tex) && slots[*tex]->loaded ? 1 : 0));
+COMMAND(0, gettextags, "i");
 
 #define LOOPTEXMRU(name,op) \
     ICOMMAND(0, looptexmru##name, "iire", (int *count, int *skip, ident *id, uint *body), \

--- a/src/engine/texture.cpp
+++ b/src/engine/texture.cpp
@@ -2735,6 +2735,15 @@ void texsmooth(int *id, int *angle)
 }
 COMMAND(0, texsmooth, "ib");
 
+void textags(char *tags)
+{
+    if(!defslot) return;
+    Slot &s = *defslot;
+    DELETEA(s.tags);
+    s.tags = tags[0] ? newstring(tags) : NULL;
+}
+ICOMMAND(0, textags, "s", (char *tags), textags(tags));
+
 void decaldepth(float *depth, float *fade)
 {
     if(!defslot || defslot->type() != Slot::DECAL) return;

--- a/src/engine/texture.h
+++ b/src/engine/texture.h
@@ -742,8 +742,9 @@ struct Slot
     float grassblend;
     int grassscale, grassheight;
     Texture *grasstex, *thumbnail;
-
-    Slot(int index = -1) : index(index), variants(NULL), grass(NULL) { reset(); }
+    char *tags;
+    
+    Slot(int index = -1) : index(index), variants(NULL), grass(NULL), tags(NULL) { reset(); }
     virtual ~Slot() {}
 
     virtual int type() const { return OCTA; }
@@ -775,6 +776,7 @@ struct Slot
         grassscale = grassheight = 0;
         grasstex = NULL;
         thumbnail = NULL;
+        DELETEA(tags);
     }
 
     void cleanup()

--- a/src/engine/worldio.cpp
+++ b/src/engine/worldio.cpp
@@ -594,6 +594,8 @@ void saveslotconfig(stream *h, Slot &s, int index, bool decal)
             if(s.grassheight > 0) h->printf("texgrassheight %d\n", s.grassheight);
         }
         if(s.variants->coastscale != 1) h->printf("texcoastscale %f\n", s.variants->coastscale);
+        
+        if(s.tags && s.tags[0]) h->printf("textags %s\n", escapestring(s.tags));
     }
     h->printf("\n");
 }


### PR DESCRIPTION
Fixes https://github.com/redeclipse/base/discussions/1204

Changes proposed in this request:
- textags / gettextags

Allows for texture slots to have descriptive names; for example:
```
setshader glowworld
texture 0 "luckystrike/pub2.jpg" // 3
texture g "luckystrike/pub2_g.jpg"
textags "billboard sign logo"
```

`gettextags <slot #>` can be called in ui scripts to match those strings when searching for textures.

If this looks ok to merge, i'll add textags to existing texture configs in cases such as "brick, vent, metal, logo, wood, paint, rust" etc where applicable. 
