### PR TITLE
Add "Clear" button to vanity selection menu

### DIFF
--- a/config/ui/profile.cfg
+++ b/config/ui/profile.cfg
@@ -733,6 +733,7 @@ uimenu "profile" "Player Profile Setup" "<grey>textures/icons/player" [
             uihlist $ui_padbutton [
                 uialign 0 1
                 uibuttonw "OK" [ui_profile_commit; uiclose "profile"] (=s $ui_profile_prev_name "") $colourgreen
+                if (= $ui_profile_tab 1) [uibuttonw "Clear" [ui_profile_prev_vanity = ""] 0 $colouryellow]
                 uibuttonw "Reset" [ui_profile_prev_reset] 0 $colourorange
                 uibuttonw "Cancel" [
                     ui_profile_haschanges = 0


### PR DESCRIPTION
Allows to quickly remove all vanities through the profile settings

![screenshot](https://user-images.githubusercontent.com/1535179/144566474-c1e96482-9818-497e-b0a5-117ec63d5b21.png)

Changes proposed in this request:
- add "Clear" button to vanities tab as seen in screenshot
