### PR TITLE
Add variables for constant first-person model offset

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -224,6 +224,10 @@ namespace game
     FVAR(IDF_PERSIST, firstpersonswayinertia, 0.0f, 0.2f, 1.0f);
     FVAR(IDF_PERSIST, firstpersonswaymaxinertia, 0.0f, 32.0f, 1000.0f);
 
+    FVAR(IDF_PERSIST, firstpersonside, -10.0f, 0.0f, 10.0f);
+    FVAR(IDF_PERSIST, firstpersonup, -10.0f, 0.0f, 10.0f);
+    FVAR(IDF_PERSIST, firstpersondist, -10.0f, 0.0f, 10.0f);
+
     VAR(IDF_PERSIST, firstpersonbob, 0, 0, 1);
     FVAR(IDF_PERSIST, firstpersonbobmin, 0, 0.2f, 1);
     FVAR(IDF_PERSIST, firstpersonbobstep, 1, 40.f, 1000);
@@ -3744,6 +3748,18 @@ namespace game
             {
                 if(!firstpersoncamera && gs_playing(gamestate) && firstpersonsway)
                     calchwepsway(mdl);
+
+                // apply constant first-person model offset
+
+                vec dirforward = vec(mdl.yaw*RAD, mdl.pitch*RAD);
+                vec dirside = vec((mdl.yaw+90)*RAD, 0.0f);
+                vec dirup = vec(mdl.yaw*RAD, (mdl.pitch+90)*RAD);
+
+                vec trans = vec(0, 0, 0);
+                trans.add(vec(dirforward).mul(firstpersondist));
+                trans.add(vec(dirside).mul(firstpersonside));
+                trans.add(vec(dirup).mul(firstpersonup));
+                mdl.o.add(trans);
 
                 if(d->sliding(true) && firstpersonslidetime && firstpersonslideroll != 0)
                 {


### PR DESCRIPTION
This can be used to make the first-person weapon model less intrusive (or left-handed, although this isn't ideal as the model itself won't be mirrored).

## Preview

Various combinations of `/firstpersonside`, `/firstpersonup` and `/firstpersondist`:

![20211228223119](https://user-images.githubusercontent.com/180032/147609246-9475ebd8-ede5-4b04-83e0-2fab1167fdaa.png)
![20211228223142](https://user-images.githubusercontent.com/180032/147609248-98c53ead-2450-4964-902c-c24be972b684.png)
![20211228223944](https://user-images.githubusercontent.com/180032/147609250-4719c678-7900-4f28-b3eb-71ad725f100e.png)
![20211228224012](https://user-images.githubusercontent.com/180032/147609252-db2e6ac9-5056-4e88-9e2a-02ce0de49eb5.png)