### PR TITLE
Add an "Always Use High-Quality Models" option to the Graphics menu

### DIFF
--- a/config/ui/settings.cfg
+++ b/config/ui/settings.cfg
@@ -38,6 +38,7 @@ ui_tip_settings_waterreflect = [uitext "Toggles screenspace reflections on water
 ui_tip_settings_caustics = [uitextleft "Toggles patches of light and dark underwater as a result of the water surface's^ntendency to randomly focus light like a lens as it moves." $ui_texttip]
 ui_tip_settings_texreduce = [uitextleft "Determines resolution of textures in level geometry." $ui_texttip]
 ui_tip_settings_envmapsize = [uitextleft "Determines resolution of environment maps for reflection effects." $ui_texttip]
+ui_tip_settings_lodmodels = [uitextleft "If checked, models will always use their high-quality variants instead of using lower-quality LOD variants when viewed from a distance." $ui_texttip]
 ui_tip_settings_particlewind = [uitextleft "Toggles particle movement with wind sources, including explosions and map wind sources." $ui_texttip]
 ui_tip_settings_softparticles = [uitextleft "Toggles smooth boundaries for particles; especially visible on weapons' halo effects." $ui_texttip]
 ui_tip_settings_stainfade = [uitextleft "Stains, like blood stains after frags or weapon bullet holes,^nare temporary to save performance." $ui_texttip]
@@ -511,6 +512,12 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                             8 "^f6High"         []
                                             10 "^f3Ultra"       []
                                         ] [uialign 1 0] "settings_envmapsize"
+                                    ]
+                                    uitablerow [
+                                        uihlist $ui_padbutton [
+                                            uicheckbox "Always Use High-Quality Models" (! $lodmodels) $ui_checksize [lodmodels = (! $lodmodels)] [] [] [] [uitooltip "settings_lodmodels"]
+                                            uialign -1 0
+                                        ]
                                     ]
 
                                     uibar 1 0


### PR DESCRIPTION
Internally, this option toggles `lodmodels` which affects the use of lower-quality LOD models when viewed from a distance.

The effect is mainly noticeable on mapmodels in maps such as Ubik.

## Preview

*View in fullscreen to see a difference on the pipes in the bottom-left corner.*

https://user-images.githubusercontent.com/180032/147613517-29e76ea5-d3ed-4ce6-9215-2eed7ba4ba89.mp4