### PR TITLE
Add settings for dynamic light and shadow quality

### DIFF
--- a/config/ui/settings.cfg
+++ b/config/ui/settings.cfg
@@ -44,6 +44,9 @@ ui_tip_settings_softparticles = [uitextleft "Toggles smooth boundaries for parti
 ui_tip_settings_stainfade = [uitextleft "Stains, like blood stains after frags or weapon bullet holes,^nare temporary to save performance." $ui_texttip]
 ui_tip_settings_grassdist = [uitextleft "Determines distance at which grass is rendered." $ui_texttip]
 ui_tip_settings_mapeffects = [uitextleft "Certain lights and mapmodels may be designated non-essential^nor optional and can be disabled to save performance." $ui_texttip]
+ui_tip_settings_dynlights = [uitextleft "If unchecked, dynamic lights for weapons and players will not be displayed.^nThis can improve performance on low-end setups." $ui_texttip]
+ui_tip_settings_smnoshadow = [uitextleft "If unchecked, point lights will not emit any shadows.^nThis can improve performance on low-end setups.^nSun shadows are not affected by this setting." $ui_texttip]
+ui_tip_settings_smdynshadow = [uitextleft "If unchecked, point and sun lights will not emit shadows for dynamic objects such as players.^nThis can improve performance on low-end setups." $ui_texttip]
 //display
 ui_tip_settings_gscale = [uitextleft "Scale of engine's rendering (leaves UIs and the HUD at native resolution)" $ui_texttip]
 ui_tip_settings_fullscreen = [uitextleft "Toggles running the game full screen (as opposed to windowed mode)" $ui_texttip]
@@ -386,6 +389,24 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                             2 "^f2Medium"       []
                                             3 "^f3High"         []
                                         ] [uialign 1 0] "settings_mapeffects"
+                                    ]
+                                    uitablerow [
+                                        uihlist $ui_padbutton [
+                                            uicheckbox "Dynamic Lights" $dynlights $ui_checksize [dynlights = (! $dynlights)] [] [] [] [uitooltip "settings_dynlights"]
+                                            uialign -1 0
+                                        ]
+                                    ]
+                                    uitablerow [
+                                        uihlist $ui_padbutton [
+                                            uicheckbox "Static Shadows" (! $smnoshadow) $ui_checksize [smnoshadow = (! $smnoshadow)] [] [] [] [uitooltip "settings_smnoshadow"]
+                                            uialign -1 0
+                                        ]
+                                    ]
+                                    uitablerow [
+                                        uihlist $ui_padbutton [
+                                            uicheckbox "Dynamic Shadows" $smdynshadow $ui_checksize [smdynshadow = (! $smdynshadow)] [] [] [] [uitooltip "settings_smdynshadow"]
+                                            uialign -1 0
+                                        ]
                                     ]
                                     uibar 1 0
                                     uitablerow [


### PR DESCRIPTION
Disabling those settings can bring a significant performance increase, especially on low-end setups such as integrated graphics. On such setups, this can make the difference between an unplayable and playable game :slightly_smiling_face: 

## Preview

*Look at the FPS counter in the top-right corner.*

### All new settings enabled (default)

![20211230191917](https://user-images.githubusercontent.com/180032/147785291-7cf7f218-9c52-46d5-97fa-53b2fb2f6d80.png)

### All new settings disabled

![20211230191922](https://user-images.githubusercontent.com/180032/147785296-82ed514a-797f-4ae2-9192-01e78be4a063.png)