### PR TITLE
Use in-out easing for better animation interpolation

### DIFF
--- a/src/engine/animmodel.h
+++ b/src/engine/animmodel.h
@@ -1123,7 +1123,9 @@ struct animmodel : model
                     if(diff<aitime)
                     {
                         p.prev.setframes(d->animinterp[interp].prev);
-                        p.interp = diff/float(aitime);
+                        // use easeInOutSine easing for smoother appearance
+                        // https://easings.net/#easeInOutSine
+                        p.interp = -(cos(M_PI * diff/float(aitime)) - 1) / 2;
                     }
                 }
             }

--- a/src/engine/rendermodel.cpp
+++ b/src/engine/rendermodel.cpp
@@ -1,7 +1,7 @@
 #include "engine.h"
 
 VAR(0, oqdynent, 0, 1, 1);
-VAR(0, animationinterpolationtime, 0, 200, 1000);
+VAR(0, animationinterpolationtime, 0, 220, 1000);
 
 model *loadingmodel = NULL;
 


### PR DESCRIPTION
Follow-up to https://github.com/redeclipse/base/pull/1326.

The difference is mainly noticeable on high refresh-rate monitors, but it affects both third-person animations and first-person weapons. The effect on first-person weapons is mainly visible after switching to certain weapons such as the pistol, shotgun and zapper.

The animation interpolation duration has been slightly lengthened to better make use of the new easing.