### PR TITLE
fix lensflare visiblity on railed lights

### DIFF
--- a/src/engine/renderparticles.cpp
+++ b/src/engine/renderparticles.cpp
@@ -1752,7 +1752,6 @@ void regularflame(int type, const vec &p, float radius, float height, int color,
 
 void lensflare(const vec &o, const vec &color, bool sun, int sparkle, float scale)
 {
-    if(!canemitparticles()) return;
     flares.addflare(o, uchar(color.r*255), uchar(color.g*255), uchar(color.b*255), sun, sparkle, scale);
 }
 

--- a/src/game/entities.cpp
+++ b/src/game/entities.cpp
@@ -2753,7 +2753,7 @@ namespace entities
                     spot = clamp(int(f.attrs[1]), 1, 89);
                 }
                 adddynlight(e.pos(), radius, color, 0, 0, e.attrs[6]|DL_ENVIRO, radius, color, NULL, dir, spot);
-                if(!flarelights) continue;
+                if(!(flarelights&2) && !(flarelights&1 && e.attrs[4])) continue;
                 bool sun = false;
                 int sparkle = 0;
                 float scale = 1.f;


### PR DESCRIPTION
Currently, when linking a light to a rail, the lensflare is always present despite e.attrs[4] being 0
* make sure lensflare isn't drawn when it's set to 0.
* also fix the flickering with lensflare particles on rails