### PR TITLE
add showmapmodels command

### DIFF
--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -870,6 +870,7 @@ extern void preloadusedmapmodels(bool msg = false, bool bih = false);
 extern int batcheddynamicmodels();
 extern int batcheddynamicmodelbounds(int mask, vec &bbmin, vec &bbmax);
 extern void cleanupmodels();
+extern int showmapmodels;
 
 static inline model *loadmapmodel(int n)
 {

--- a/src/engine/rendermodel.cpp
+++ b/src/engine/rendermodel.cpp
@@ -1024,9 +1024,11 @@ model *loadlodmodel(model *m, const vec &pos, float offset)
     return lm ? lm : m;
 }
 
+VAR(0, showmapmodels, 0, 1, 1);
+
 void rendermapmodel(int idx, entmodelstate &state, bool tpass)
 {
-    if(!mapmodels.inrange(idx)) return;
+    if(!mapmodels.inrange(idx) || (editmode && !showmapmodels)) return;
     mapmodelinfo &mmi = mapmodels[idx];
     model *m = loadlodmodel(mmi.m ? mmi.m : loadmodel(mmi.name), state.o, state.lodoffset);
     if(!m) return;
@@ -1210,4 +1212,3 @@ void setbbfrommodel(dynent *d, const char *mdl, float size)
         d->height += zrad;
     }
 }
-

--- a/src/game/entities.cpp
+++ b/src/game/entities.cpp
@@ -2903,6 +2903,7 @@ namespace entities
                 }
             }
 
+            if (editmode && !showmapmodels) return;
             loopvj(r.parents)
             {
                 int n = r.parents[j];


### PR DESCRIPTION
* skips mapmodel rendering when in edit mode
* allows to easily edit geometry behind mapmodels without having to move the entities

