### PR TITLE
fix msaa on AA ultra settings

### DIFF
--- a/config/ui/settings.cfg
+++ b/config/ui/settings.cfg
@@ -317,7 +317,7 @@ aalevels = [
         tqaa 0
         smaa 0
         smaaquality 0
-        msaa 16
+        msaa 0
     ]
 ]
 //ui scales by area (2x area = 1.4x linear dimension increase)


### PR DESCRIPTION
msaa 16 and everything grater msaa 1 messed up the flame particles and turn them into kinda black haze
only msaa 0 and msaa 1 works
I am still not sure if msaa 0 or msaa 1 fits better for the ultra settings
