### PR TITLE
clearshadowcache on world reset

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3235,6 +3235,7 @@ namespace game
 
     void resetworld()
     {
+        clearshadowcache();
         specreset();
         hud::showscores(false);
         UI::closeui(NULL);


### PR DESCRIPTION
* shadows don't correctly update unless clearshadowcache() is called once

Placing a spinning mapmodel in front of a light causes the shadow to remain static on mapload. Noticed that in the editor as soon as you focus on the entity with a mouse click, the shadow starts moving as expected due to clearshadowcache().

Adding that call to resetworld() allows shadows to start rendering correctly. 

Video of the problem this fixes; https://cdn.discordapp.com/attachments/504927538078810112/991913673650098226/out-2022-06-30_04.48.36.mp4