### PR TITLE
fix Cmake deprecation warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.12)
+
+project(redeclipse)
 
 # link_deps([FATAL] DEPS <deps>..)
 # Calls link_directories for <deps>. <deps> is a list of dependencies.

--- a/src/enet/CMakeLists.txt
+++ b/src/enet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(enet)
 


### PR DESCRIPTION
Missing `project(redeclipse)`;
```
CMake Warning (dev) in CMakeLists.txt:
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().
```

Also for *src/CMakeLists.txt* and *src/enet/CMakeLists.txt*;
```
  CMake is pretending there is a "project(Project)" command on the first
  line.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

2.8.12 was released in 2013, seems logical to bump to this version for compatibility just to suppress these warnings.
