### PR TITLE
SDL.h to SDL2/SDL.h (compiles on SDL1 systems).

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -393,14 +393,6 @@ clean-tessfont:
 
 clean: clean-enet clean-client clean-server clean-genkey clean-tessfont
 
-
-DEPENDS  = $(shell find . -name '*.d')
-ALL_OBJS = $(shell find . -name '*.o')
-
-clean2:
-	@echo "'clean' = remove all *.d & *.o in project:" 
-	@rm -rf $(DEPENDS) $(ALL_OBJS)
-
 %.h.gch: %.h
 	$(CXX) $(CXXFLAGS) -x c++-header -o $(subst .h.gch,.tmp.h.gch,$@) $(subst .h.gch,.h,$@)
 	$(MV) $(subst .h.gch,.tmp.h.gch,$@) $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -103,7 +103,7 @@ ifneq (,$(findstring msvc,$(PLATFORM)))
     CC = clang
 else
     override CXX := $(TOOLSET_PREFIX)$(CXX)
-    override CC := $(TOOLSET_PREFIX)$(CC)
+    override CC  := $(TOOLSET_PREFIX)$(CC)
 endif
 
 INCLUDES = -DVERSION_BUILD=$(PLATFORM_BUILD) \
@@ -393,6 +393,14 @@ clean-tessfont:
 
 clean: clean-enet clean-client clean-server clean-genkey clean-tessfont
 
+
+DEPENDS  = $(shell find . -name '*.d')
+ALL_OBJS = $(shell find . -name '*.o')
+
+clean2:
+	@echo "'clean' = remove all *.d & *.o in project:" 
+	@rm -rf $(DEPENDS) $(ALL_OBJS)
+
 %.h.gch: %.h
 	$(CXX) $(CXXFLAGS) -x c++-header -o $(subst .h.gch,.tmp.h.gch,$@) $(subst .h.gch,.h,$@)
 	$(MV) $(subst .h.gch,.tmp.h.gch,$@) $@
@@ -505,6 +513,7 @@ include dist.mk
 include wiki.mk
 
 engine/engine.h.gch: engine/version.h shared/cube.h.gch
+
 
 # DO NOT DELETE
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -506,7 +506,6 @@ include wiki.mk
 
 engine/engine.h.gch: engine/version.h shared/cube.h.gch
 
-
 # DO NOT DELETE
 
 shared/crypto.o: shared/cube.h shared/tools.h shared/command.h shared/geom.h

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -251,13 +251,16 @@ void setupdisplay(bool dogl = true, bool msg = true)
     SDL_GL_GetDrawableSize(screen, &renderw, &renderh);
 
     int index = getdisplaymode();
+    
     if(windowfocus && SDL_GetWindowFlags(screen)&SDL_WINDOW_FULLSCREEN && (display.w != screenw || display.h != screenh))
     {
-        scr_w = clamp(display.w, SCR_MINW, SCR_MAXW);
-        scr_h = clamp(display.h, SCR_MINH, SCR_MAXH);
-        resetfullscreen();
-        SDL_GetWindowSize(screen, &screenw, &screenh);
-        SDL_GL_GetDrawableSize(screen, &renderw, &renderh);
+        // FIX fullscreen loop:
+        SDL_MaximizeWindow(screen);
+        //scr_w = clamp(display.w, SCR_MINW, SCR_MAXW);
+        //scr_h = clamp(display.h, SCR_MINH, SCR_MAXH);
+        //resetfullscreen();
+        //SDL_GetWindowSize(screen, &screenw, &screenh);
+        //SDL_GL_GetDrawableSize(screen, &renderw, &renderh);
     }
     scr_w = screenw;
     scr_h = screenh;
@@ -276,8 +279,10 @@ void setfullscreen(bool enable)
     SDL_SetWindowFullscreen(screen, enable ? (fullscreendesktop ? SDL_WINDOW_FULLSCREEN_DESKTOP : SDL_WINDOW_FULLSCREEN) : 0);
     if(!enable)
     {
-        SDL_SetWindowSize(screen, scr_w, scr_h);
-        SDL_SetWindowPosition(screen, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+        // FIX fullscreen loop:
+        if(SDL_GetWindowFlags(screen)&SDL_WINDOW_MAXIMIZED) { SDL_RestoreWindow(screen); }
+        //SDL_SetWindowSize(screen, scr_w, scr_h);
+        //SDL_SetWindowPosition(screen, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
     }
     wantdisplaysetup = true;
 }

--- a/src/shared/cube.h
+++ b/src/shared/cube.h
@@ -50,8 +50,8 @@
     #include <OpenGL/gl.h>
     #define main SDL_main
   #else
-    #include <SDL.h>
-    #include <SDL_opengl.h>
+    #include <SDL2/SDL.h>
+    #include <SDL2/SDL_opengl.h>
   #endif
 #endif
 


### PR DESCRIPTION
Fixes #
Compile will fail on systems that have SDL1 installed (which is still updated for older apps like Cube1 -- this version works on both & should be SDLx future proof).

Changes proposed in this request:
SDL.h to SDL2/SDL.h 