### PR TITLE
remove purge to map rotation

### DIFF
--- a/config/version.cfg
+++ b/config/version.cfg
@@ -18,7 +18,6 @@ version_maplist = [
     octavus     [allow large main capture defend bomber hold]
     panopticon  [allow medium main defend king hold]
     parker      [allow small main duel gladiator]
-    purge       [allow race]
     rift        [allow large main capture defend king bomber hold]
     trespass    [allow small main duel]
     ubik        [allow medium main defend king hold]


### PR DESCRIPTION
I give purge now the final purge
I will no longer working on it, it will not fit to the game any longer on design shape and game play standpoints. (latest version can be found under discussions https://github.com/orgs/redeclipse/discussions/1215 )
