### PR TITLE
Allow `smsize 15` for better shadow map resolution

### DIFF
--- a/src/engine/renderlights.cpp
+++ b/src/engine/renderlights.cpp
@@ -1946,7 +1946,7 @@ FVAR(0, smprec, 1e-3f, 1, 1e3f);
 FVAR(0, smcubeprec, 1e-3f, 1, 1e3f);
 FVAR(0, smspotprec, 1e-3f, 1, 1e3f);
 
-VARF(IDF_PERSIST, smsize, 10, 12, 14, cleanupshadowatlas());
+VARF(IDF_PERSIST, smsize, 10, 12, 15, cleanupshadowatlas());
 VARF(IDF_PERSIST, smdepthprec, 0, 0, 2, cleanupshadowatlas());
 VAR(0, smsidecull, 0, 1, 1);
 VAR(0, smviscull, 0, 1, 1);


### PR DESCRIPTION
This results in sharper, more stable shadows that better connect to the object casting them (with less acne/peter-panning).

This is a demanding setting compared to `/smsize 14`, but modern high-end GPUs[^1] can still render the game smoothly with `/smsize 15` in most maps. Still, given how demanding this setting is, it's intentionally not exposed in the graphics options menu.

I also tried exposing `/smsize 16` for fun, but it looks the same as `/smsize 15` – presumably because GPUs don't support such large textures in the first place. (I'm surprised `/smsize 15` even works here…; I remember when smoothly using `/smsize 14` was just a pipe dream.)

[^1]: Roughly RTX 3080 level in terms of rasterization performance or better.
