### PR TITLE
disable weapon switching when editing

### DIFF
--- a/src/game/weapons.cpp
+++ b/src/game/weapons.cpp
@@ -145,6 +145,7 @@ namespace weapons
 
     void weaponswitch(gameent *d, int a = -1, int b = -1)
     {
+        if(d->state == CS_EDITING) return;
         if(!gs_playing(game::gamestate) || a < -1 || b < -1 || a >= W_ALL || b >= W_ALL) return;
         if(weapselectdelay && lastweapselect && totalmillis-lastweapselect < weapselectdelay) return;
         if(d->weapwaited(d->weapselect, lastmillis, (1<<W_S_SWITCH)|(1<<W_S_RELOAD)))


### PR DESCRIPTION
Stops sync errors when pressing default binds for MOUSE4/MOUSE5 in CS_EDITING state.
```
2024-04-25 07:48.58 Sync error: player switch [8] failed - unexpected message
2024-04-25 07:49.01 Sync error: player switch [3] failed - unexpected message
```