### PR TITLE
search box searches for partial matches instead of full matches

### DIFF
--- a/config/ui/vars.cfg
+++ b/config/ui/vars.cfg
@@ -188,8 +188,11 @@ newui "vars" $SURFACE_FOREGROUND [
     uiallowinput 1
 
     local numvars scurflag scurvar searchstr
-    searchstr = (concatword $ui_vars_searchstr (? (|| (>= (strstr $ui_vars_searchstr "*") 0) (>= (strstr $ui_vars_searchstr "?") 0)) "" "*"))
-    numvars = (getvarinfo -1 $ui_vars_types $ui_vars_notypes $ui_vars_flags $ui_vars_noflags $ui_vars_searchstr 3)
+    // Remove the restrictive `?` and `*` checks for flexible matching
+    searchstr = (concatword $ui_vars_searchstr "*")  // Using `*` wildcard for broader match
+
+    // Perform a flexible search using the updated `searchstr`
+    numvars = (getvarinfo -1 $ui_vars_types $ui_vars_notypes $ui_vars_flags $ui_vars_noflags $searchstr 3)
 
     if (>= $ui_vars_num $numvars) [ ui_vars_init ]
 
@@ -205,7 +208,8 @@ newui "vars" $SURFACE_FOREGROUND [
                     uistyle lefttop
                     uivlist $ui_padbutton [
                         uistyle lefttop
-                        uiinput ui_vars_searchstr 32 [ui_vars_num = -1] 1 0 "[click here to enter wildcard search text]" 0 [] [uialtrelease [ui_vars_searchstr = ""]]
+                        // Changed the search function to use `ui_vars_searchstr`
+                        uiinput ui_vars_searchstr 32 [ui_vars_num = -1; ui_vars_page = 0] 1 0 "[click here to enter search text]" 0 [] [uialtrelease [ui_vars_searchstr = ""]]
                         uihlist 0 [
                             uistyle clampx
                             uistyle leftmiddle
@@ -281,7 +285,7 @@ newui "vars" $SURFACE_FOREGROUND [
                                         uihlist 0 [
                                             uistyle clampx
                                             uialign -1
-                                            ui_vars_curname = (getvarinfo $n $ui_vars_types $ui_vars_notypes $ui_vars_flags $ui_vars_noflags $ui_vars_searchstr 3)
+                                            ui_vars_curname = (getvarinfo $n $ui_vars_types $ui_vars_notypes $ui_vars_flags $ui_vars_noflags $searchstr 3)
                                             uiradio $ui_vars_curname (= $ui_vars_num $n) $ui_radiosize [ui_vars_num = @n]
                                         ]
                                     ]
@@ -316,7 +320,7 @@ newui "vars" $SURFACE_FOREGROUND [
                     uistyle lefttop
                     uihlist 0 [uispace 0.3]
                     if (&& (>= $ui_vars_num 0) (< $ui_vars_num $numvars) (> $numvars 0)) [
-                        scurvar = (getvarinfo $ui_vars_num $ui_vars_types $ui_vars_notypes $ui_vars_flags $ui_vars_noflags $ui_vars_searchstr)
+                        scurvar = (getvarinfo $ui_vars_num $ui_vars_types $ui_vars_notypes $ui_vars_flags $ui_vars_noflags $searchstr)
                         uivlist $ui_padbutton [
                             uistyle lefttop
                             ui_vars_display $scurvar


### PR DESCRIPTION
Fixes #1564

Changes proposed in this request:
- Modify the search functionality in the vars menu to search for partial matches by appending a wildcard (*) to the end of the user's search query.
- Example: Before this change, searching for "shotgun" would yield no results if there was no exact match. With this change, searching "shotgun" will display all variables starting with "shotgun".
- This enhancement improves usability by allowing users to find variables more flexibly without requiring exact matches.

This change was implemented by adjusting the search query handler to append the wildcard character to search query.
