### PR TITLE
add temporary loadout

### DIFF
--- a/config/ui/game/hud/pie.cfg
+++ b/config/ui/game/hud/pie.cfg
@@ -440,7 +440,7 @@ game_hud_piemenu_weapsel_checkloadout = [
     local _result
     _result = 1
 
-    looplist i $playertemploadweap [
+    looplist i $playerloadweap [
         if (! (getclientweaphold $ui_hud_focus $i)) [
             _result = 0
         ]
@@ -457,19 +457,19 @@ game_hud_piemenu_weapsel_checkloadout = [
     _loadout = []
 
     if (=s $game_hud_piemenu_weapsel_prevloadout []) [
-        game_hud_piemenu_weapsel_prevloadout = $playertemploadweap
-        _loadout = $playertemploadweap
+        game_hud_piemenu_weapsel_prevloadout = $playerloadweap
+        _loadout = $playerloadweap
     ] [
-        if (!=s $playertemploadweap $game_hud_piemenu_weapsel_prevloadout) [
+        if (!=s $playerloadweap $game_hud_piemenu_weapsel_prevloadout) [
             if (game_hud_piemenu_weapsel_checkloadout) [
-                game_hud_piemenu_weapsel_prevloadout = $playertemploadweap
-                _loadout = $playertemploadweap
+                game_hud_piemenu_weapsel_prevloadout = $playerloadweap
+                _loadout = $playerloadweap
             ] [
                 // New loadout not equipped yet, keep the old one
                 _loadout = $game_hud_piemenu_weapsel_prevloadout
             ]
         ] [
-            _loadout = $playertemploadweap
+            _loadout = $playerloadweap
         ]
     ]
 

--- a/config/ui/game/hud/pie.cfg
+++ b/config/ui/game/hud/pie.cfg
@@ -440,7 +440,7 @@ game_hud_piemenu_weapsel_checkloadout = [
     local _result
     _result = 1
 
-    looplist i $playerloadweap [
+    looplist i $playertemploadweap [
         if (! (getclientweaphold $ui_hud_focus $i)) [
             _result = 0
         ]
@@ -457,19 +457,19 @@ game_hud_piemenu_weapsel_checkloadout = [
     _loadout = []
 
     if (=s $game_hud_piemenu_weapsel_prevloadout []) [
-        game_hud_piemenu_weapsel_prevloadout = $playerloadweap
-        _loadout = $playerloadweap
+        game_hud_piemenu_weapsel_prevloadout = $playertemploadweap
+        _loadout = $playertemploadweap
     ] [
-        if (!=s $playerloadweap $game_hud_piemenu_weapsel_prevloadout) [
+        if (!=s $playertemploadweap $game_hud_piemenu_weapsel_prevloadout) [
             if (game_hud_piemenu_weapsel_checkloadout) [
-                game_hud_piemenu_weapsel_prevloadout = $playerloadweap
-                _loadout = $playerloadweap
+                game_hud_piemenu_weapsel_prevloadout = $playertemploadweap
+                _loadout = $playertemploadweap
             ] [
                 // New loadout not equipped yet, keep the old one
                 _loadout = $game_hud_piemenu_weapsel_prevloadout
             ]
         ] [
-            _loadout = $playerloadweap
+            _loadout = $playertemploadweap
         ]
     ]
 

--- a/config/ui/game/player.cfg
+++ b/config/ui/game/player.cfg
@@ -166,7 +166,7 @@ gameui_player_reset = [
     ]
 
     // Get saved loadout
-    gameui_player_loadout_slots  = $playerloadweap
+    gameui_player_loadout_slots  = $playersavedloadweap
 
     // Get loadout random filter
     gameui_player_loadout_filter = 0
@@ -189,7 +189,7 @@ gameui_player_set = [
     // Don't attempt to set loadout if it's invalid
     if (gameui_player_loadout_validate) [
         playerloadweap $gameui_player_loadout_slots
-        defsvarp playertemploadweap $gameui_player_loadout_slots
+        defsvarp playersavedloadweap $gameui_player_loadout_slots
 
         // Set loadout random filter
         local _tmp
@@ -203,7 +203,7 @@ gameui_player_set = [
 
 gameui_player_temporary_loadout_set = [
     if (gameui_player_loadout_validate) [
-        defsvarp playertemploadweap $gameui_player_loadout_slots
+        playerloadweap $gameui_player_loadout_slots
 
         // Set loadout random filter
         local _tmp

--- a/config/ui/game/player.cfg
+++ b/config/ui/game/player.cfg
@@ -189,6 +189,7 @@ gameui_player_set = [
     // Don't attempt to set loadout if it's invalid
     if (gameui_player_loadout_validate) [
         playerloadweap $gameui_player_loadout_slots
+        defsvarp playertemploadweap $gameui_player_loadout_slots
 
         // Set loadout random filter
         local _tmp
@@ -202,7 +203,7 @@ gameui_player_set = [
 
 gameui_player_temporary_loadout_set = [
     if (gameui_player_loadout_validate) [
-        playertemploadweap $gameui_player_loadout_slots
+        defsvarp playertemploadweap $gameui_player_loadout_slots
 
         // Set loadout random filter
         local _tmp

--- a/config/ui/game/player.cfg
+++ b/config/ui/game/player.cfg
@@ -166,7 +166,7 @@ gameui_player_reset = [
     ]
 
     // Get saved loadout
-    gameui_player_loadout_slots  = $playersavedloadweap
+    gameui_player_loadout_slots  = $playerloadweap
 
     // Get loadout random filter
     gameui_player_loadout_filter = 0

--- a/config/ui/game/player.cfg
+++ b/config/ui/game/player.cfg
@@ -166,7 +166,7 @@ gameui_player_reset = [
     ]
 
     // Get loadout
-    gameui_player_loadout_slots  = $playerloadweap
+    gameui_player_loadout_slots  = $playertemploadweap
 
     // Get loadout random filter
     gameui_player_loadout_filter = 0
@@ -188,7 +188,7 @@ gameui_player_set = [
 
     // Don't attempt to set loadout if it's invalid
     if (gameui_player_loadout_validate) [
-        playerloadweap $gameui_player_loadout_slots
+        playertemploadweap $gameui_player_loadout_slots
 
         // Set loadout random filter
         local _tmp

--- a/config/ui/game/player.cfg
+++ b/config/ui/game/player.cfg
@@ -165,8 +165,8 @@ gameui_player_reset = [
         append gameui_player_vanities_ids (gameui_player_find_vanity (at $gameui_player_vanities $i))
     ]
 
-    // Get loadout
-    gameui_player_loadout_slots  = $playertemploadweap
+    // Get saved loadout
+    gameui_player_loadout_slots  = $playerloadweap
 
     // Get loadout random filter
     gameui_player_loadout_filter = 0
@@ -187,6 +187,20 @@ gameui_player_set = [
     playervanity   $gameui_player_vanities
 
     // Don't attempt to set loadout if it's invalid
+    if (gameui_player_loadout_validate) [
+        playerloadweap $gameui_player_loadout_slots
+
+        // Set loadout random filter
+        local _tmp
+        _tmp = []
+        loop i 32 [
+            append _tmp (& $gameui_player_loadout_filter (<< 1 $i))
+        ]
+        playerrandweap $_tmp
+    ]
+]
+
+gameui_player_temporary_loadout_set = [
     if (gameui_player_loadout_validate) [
         playertemploadweap $gameui_player_loadout_slots
 
@@ -650,6 +664,24 @@ gameui_player_loadout_open_overlay = [
                 uirelease [
                     gameui_player_loadout_filter = (^ $gameui_player_loadout_filter (<< 1 $i))
                 ]
+            ]
+        ]
+    ]
+
+    uifill 0 0.03
+
+    uihlist 0.05 [
+        uivlist 0.01 [
+            ui_gameui_button [
+                p_label       = "Save for Match"
+                p_label_size  = 1.5
+                p_width       = 0.144
+                p_height      = 0.05
+                p_on_click    = [
+                    gameui_player_temporary_loadout_set
+                ]
+                p_border_scale = 0.5
+                p_id          = #(gameui_get_id button)
             ]
         ]
     ]
@@ -1576,7 +1608,7 @@ ui_gameui_player_dims = 1.2
 
                             uihlist 0 [
                                 ui_gameui_button [
-                                    p_label       = "Reset"
+                                    p_label       = "Undo Changes"
                                     p_label_size  = 1.5
                                     p_width       = 0.144
                                     p_height      = 0.05

--- a/config/ui/game/player.cfg
+++ b/config/ui/game/player.cfg
@@ -166,7 +166,7 @@ gameui_player_reset = [
     ]
 
     // Get saved loadout
-    gameui_player_loadout_slots  = $playerloadweap
+    gameui_player_loadout_slots  = $playersavedloadweap
 
     // Get loadout random filter
     gameui_player_loadout_filter = 0

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -581,7 +581,12 @@ namespace client
         }
         sendplayerinfo = true;
     }
-    SVARF(IDF_PERSIST, playerloadweap, "", setloadweap(playerloadweap));
+
+    void resetloadweap(const char *list)
+    {
+        SVARF(IDF_PERSIST, playertemploadweap, "", setloadweap(playertemploadweap));  // temporary weapon loadout, all cases where playerloadweap is read now read this
+    }
+    SVARF(IDF_PERSIST, playerloadweap, "", resetloadweap(playerloadweap);  // no longer executes setloadweap, instead updates playertemploadweap
 
     void setrandweap(const char *list)
     {

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -581,12 +581,7 @@ namespace client
         }
         sendplayerinfo = true;
     }
-
-    void resetloadweap(const char *list)
-    {
-        SVARF(IDF_PERSIST, playertemploadweap, "", setloadweap(playertemploadweap));  // temporary weapon loadout, all cases where playerloadweap is read now read this
-    }
-    SVARF(IDF_PERSIST, playerloadweap, "", resetloadweap(playerloadweap);  // no longer executes setloadweap, instead updates playertemploadweap
+    SVARF(IDF_PERSIST, playerloadweap, "", setloadweap(playerloadweap));
 
     void setrandweap(const char *list)
     {

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -581,12 +581,13 @@ namespace client
         }
         sendplayerinfo = true;
     }
-
+    SVARF(IDF_PERSIST, playertemploadweap, "", setloadweap(playertemploadweap));  // temporary weapon loadout, all cases where playerloadweap is read now read this
     void resetloadweap(const char *list)
     {
-        SVARF(IDF_PERSIST, playertemploadweap, "", setloadweap(playertemploadweap));  // temporary weapon loadout, all cases where playerloadweap is read now read this
+        playertemploadweap = playerloadweap;
     }
-    SVARF(IDF_PERSIST, playerloadweap, "", resetloadweap(playerloadweap);  // no longer executes setloadweap, instead updates playertemploadweap
+    SVARF(IDF_PERSIST, playerloadweap, "", resetloadweap(playerloadweap));  // no longer executes setloadweap, instead updates playertemploadweap
+
 
     void setrandweap(const char *list)
     {

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -581,13 +581,12 @@ namespace client
         }
         sendplayerinfo = true;
     }
-    SVARF(IDF_PERSIST, playertemploadweap, "", setloadweap(playertemploadweap));  // temporary weapon loadout, all cases where playerloadweap is read now read this
+
     void resetloadweap(const char *list)
     {
-        playertemploadweap = playerloadweap;
+        SVARF(IDF_PERSIST, playertemploadweap, "", setloadweap(playertemploadweap));  // temporary weapon loadout, all cases where playerloadweap is read now read this
     }
-    SVARF(IDF_PERSIST, playerloadweap, "", resetloadweap(playerloadweap));  // no longer executes setloadweap, instead updates playertemploadweap
-
+    SVARF(IDF_PERSIST, playerloadweap, "", resetloadweap(playerloadweap);  // no longer executes setloadweap, instead updates playertemploadweap
 
     void setrandweap(const char *list)
     {


### PR DESCRIPTION
Fixes #1363

Changes proposed in this request:
- add new SVAR: playertemploadweap, most instances of playerloadweap now use playertemploadweap, some specificly don't (such as the reset button)
- the reset button has been renamed to "Undo Changes" for clarity
- when playerloadweap changes it also sets playertemploadweap to the same value
- playertemploadweap now also can be updated without affecting playerloadweap, with a button on the loadout menu to do so.
