### PR TITLE
add option to ping servers imediately, ignoring waiting for serverupdateinterval

### DIFF
--- a/config/ui/game/online.cfg
+++ b/config/ui/game/online.cfg
@@ -23,7 +23,11 @@ gameui_online_ver_check = [
 
 gameui_online_update = [
     if (>=f $gameui_panel_anim 1) [
-        updateservers
+        if (> $_lastping 0) [
+            updateservers
+        ] [
+            updateservers 1
+        ]
     ]
 ]
 
@@ -203,7 +207,7 @@ ui_gameui_online_entry_mapshot = [
     uipad 0.02 0 0 0 [
         uialign -1
         uicolour 0 0.2 $_size [
-            if (>= $_lastping 0) [
+            if (>= $+++++ 0) [
                 uitext "?" 4
                 uicroppedimage (concatword "maps/" $_mapname) 0xffffff 0 0.2 $_size 0 (+f (*f $_size -2.5) 0.5) 1 (divf $_size 0.2) [
                     uispace 0 0.01 [

--- a/config/ui/game/online.cfg
+++ b/config/ui/game/online.cfg
@@ -22,13 +22,14 @@ gameui_online_ver_check = [
 ]
 
 gameui_online_update = [
-    if (>=f $gameui_panel_anim 1) [
-        if (> $_lastping 0) [
+    if (> $_lastping 0) [
+        if (>=f $gameui_panel_anim 1) [
             updateservers
-        ] [
-            updateservers 1
         ]
+    ] [
+        updateservers 1
     ]
+    
 ]
 
 ui_gameui_online_connect_on_close = [

--- a/src/engine/serverbrowser.cpp
+++ b/src/engine/serverbrowser.cpp
@@ -389,7 +389,7 @@ void checkpings()
 
 static inline int serverinfocompare(serverinfo *a, serverinfo *b) { return client::servercompare(a, b) < 0; }
 
-void refreshservers()
+void refreshservers(const int update_now = 0)
 {
     static int lastrefresh = 0;
     if(lastrefresh == totalmillis) return;
@@ -403,7 +403,7 @@ void refreshservers()
 
     checkresolver();
     checkpings();
-    if(totalmillis - lastinfo >= (serverupdateinterval*1000)/(maxservpings ? max(1, (servers.length() + maxservpings - 1) / maxservpings) : 1)) pingservers();
+    if(totalmillis - lastinfo >= (serverupdateinterval*1000)/(maxservpings ? max(1, (servers.length() + maxservpings - 1) / maxservpings) : 1) || update_now = 1) pingservers();
 }
 
 bool reqmaster = false;
@@ -499,14 +499,14 @@ void updatefrommaster()
         else conoutf(colourgrey, "Retrieved list from master successfully");
     }
     else conoutf(colourred, "Master server not replying");
-    refreshservers();
+    refreshservers(1);
 }
 COMMAND(IDF_NOECHO, updatefrommaster, "");
 
-void updateservers()
+void updateservers(const int update_now = 0)
 {
     if(!reqmaster) updatefrommaster();
-    refreshservers();
+    refreshservers(update_now);
     if(autosortservers && !pausesortservers) sortservers();
     intret(servers.length());
 }


### PR DESCRIPTION
Fixes #915

Changes proposed in this request:
serverbrowser.cpp:
- add argument "update_now" to functions `updateservers` and `refreshservers`. it defaults to 0
- `updateservers` only passes it to `refreshservers`
- `updatefrommaster` now calls `refreshservers` with update_now set to 1
- in `refreshservers` the check for if enough time has elapsed based on `serverupdateinterval` now has an OR check to see if update_now is 1, if it is then it will update regardless of when the last update was

online.cfg:
- when `gameui_online_update` is called it checks to see if we have pinged before in this session, if we have then call `updateservers` with `update_now` at the default value (0), if not then call it with `update_now` set to 1 forcing an immediate ping regardless of when the last ping was

With these changes the server list will ping servers immediately upon being opened (before the animation) making the only delay in the time it takes to ping