### PR TITLE
Update maps.cfg disable start button when demo mode is selected with no demo selected

### DIFF
--- a/config/ui/game/maps.cfg
+++ b/config/ui/game/maps.cfg
@@ -213,13 +213,10 @@ gameui_sort_maps = [
             ]
 
             uirelease [
-                // Select first map/demo when switching between demo and normal modes
-                caseif (&& [! $gameui_maps_mode] $arg1) [
-                    gameui_maps_map = -1
-                ] (&& $gameui_maps_mode [! $arg1]) [
-                    gameui_maps_map = 0
-                ]
+                // Select first map/no demo when switching between demo and normal modes
+                gameui_maps_map = -1
 
+ 
                 gameui_maps_mode     = $arg1
                 gameui_maps_mode_pos = (+f $uilastsx (*f $uilastw 0.5))
                 gameui_sort_maps
@@ -851,7 +848,8 @@ gameui_maps_pointlimit_options = [
                         ]
                         p_colour      = #(hsvtohex 8 0.3 1)
                         p_highlight   = 1
-                        p_disabled    = (< $gameui_maps_mode 0)
+                        // check if we user has selected a mode, if they select demo mode and there are no maps then disable the button
+                        p_disabled    = (|| [< $gameui_maps_mode 0] [&& [= $gameui_maps_mode 0] [= $gameui_maps_map -1]])
                         p_id          = #(gameui_get_id button)
                     ]
                 ]


### PR DESCRIPTION
Fixes #1521

Changes proposed in this request:
- no demo is selected by default when switching to demo mode `gameui_maps_map` is -1 now instead of 0
- extended check to the begin button being disabled to check if demo mode is selected but no demo is selected

This prevents opening demo mode when there are no demos avalible.