### PR TITLE
Update server.cpp to get map from vote starter

### DIFF
--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -3221,7 +3221,7 @@ namespace server
 
     enum { ALST_TRY = 0, ALST_SPAWN, ALST_SPEC, ALST_EDIT, ALST_WALK, ALST_MAX };
 
-    bool getmap(clientinfo *ci = NULL, bool force = false);
+    bool getmap(clientinfo *ci = NULL, bool force = false, int votingclientnum = -1);
 
     bool crclocked(clientinfo *ci, bool msg = false)
     {
@@ -3312,7 +3312,7 @@ namespace server
         return true;
     }
 
-    bool getmap(clientinfo *ci, bool force)
+    bool getmap(clientinfo *ci, bool force, int votingclientnum)
     {
         if(gs_intermission(gamestate)) return false; // pointless
 
@@ -3354,7 +3354,20 @@ namespace server
         if((!force && gs_waiting(gamestate)) || mapsending >= 0 || hasmapdata()) return false;
 
         clientinfo *best = NULL;
-        if(!m_edit(gamemode) || force)
+        if(votingclientnum >= 0)
+        {
+            loopv(clients)
+            {
+                clientinfo *vc = clients[i];
+                if(vc->clientnum == votingclientnum && vc->clientcrc && vc->ready)
+                {
+                    best = vc;
+                    break;
+                }
+            }
+        }
+
+        if(!best && !m_edit(gamemode) || force)
         {
             vector<clientcrcs> crcs;
             loopv(clients)
@@ -5558,7 +5571,7 @@ namespace server
 
                             if(!hasmapdata())
                             {
-                                if(mapsending < 0) getmap(NULL, true);
+                                if(mapsending < 0) getmap(NULL, true, mapgameinfo);
 
                                 if(mapsending >= 0)
                                 {


### PR DESCRIPTION
Fixes #1012

Changes proposed in this request:
- if the server does not have the map of the winning vote then the server now gets the map from the player who started the vote, instead of the player who was on the server the longest. 
- This is implementing by adding an argument to `getmap` for the vote starter's user id (number, not username). it tries to get the map from this player first. it defaults to -1 which is not a player so if it is unspecified then it will use the old functionality.
- The old functionality is used as a fallback in case getting the map from the vote starter fails. If the server already has the map it simply uses that (same as before).
