### PR TITLE
Update servinit.cfg

### DIFF
--- a/doc/examples/servinit.cfg
+++ b/doc/examples/servinit.cfg
@@ -63,6 +63,7 @@ if (= $rehashing 0) [
 // Server auth handling
 //
 // serverauthconnect 1 // determines if the server should attempt to auth
+// steamserver 0 // determines if the server should attempt use Steam ID to auth
 // serveraccountname handle // server's auth handle
 // serveraccountpass privkey // server's private key
 // serverauthkey handle privkey // combines serveraccountname and serveraccountpass


### PR DESCRIPTION
add steamserver 0 to reduce problems with not yet active steam ID auth. (should be set 0 in defaults too)